### PR TITLE
feat: add --effort passthrough and --version flag

### DIFF
--- a/claude_openai_api.go
+++ b/claude_openai_api.go
@@ -21,6 +21,8 @@ import (
 	"time"
 )
 
+var version = "dev"
+
 // ---- OpenAI-compatible request/response types ----
 
 type ChatCompletionRequest struct {
@@ -38,6 +40,7 @@ type ChatCompletionRequest struct {
 	EnvVars       map[string]string `json:"env_vars,omitempty"`
 	MaxTurns      *int              `json:"max_turns,omitempty"`
 	SessionID     string            `json:"session_id,omitempty"`
+	Effort        string            `json:"effort,omitempty"`
 }
 
 type StreamOptions struct {
@@ -910,6 +913,10 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
 		maxTurns = *req.MaxTurns
 	}
 	args = append(args, "--max-turns", fmt.Sprintf("%d", maxTurns))
+
+	if req.Effort != "" {
+		args = append(args, "--effort", req.Effort)
+	}
 
 	if req.SessionID != "" {
 		args = append(args, "--resume", req.SessionID)
@@ -2039,8 +2046,9 @@ func oaiHealthHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{
-		"status": "healthy",
-		"claude": "available",
+		"status":  "healthy",
+		"claude":  "available",
+		"version": version,
 	})
 }
 
@@ -2070,7 +2078,13 @@ func main() {
 	port := flag.String("port", "50009", "port to listen on")
 	proxy := flag.String("proxy", "", "HTTP/HTTPS proxy URL (e.g. http://127.0.0.1:7890)")
 	model := flag.String("model", "", "default model name (e.g. MiniMax-M2.7, claude-sonnet-4-6)")
+	showVersion := flag.Bool("version", false, "show version and exit")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version)
+		os.Exit(0)
+	}
 
 	if *model != "" {
 		defaultModel = *model


### PR DESCRIPTION
## Summary
- Add `effort` field to `ChatCompletionRequest`, transparently passed to Claude CLI as `--effort <level>` (low/medium/high/max) to control reasoning depth
- Add `var version` with `-ldflags` build-time override and `--version` CLI flag for version inspection
- Include `version` in `/health` endpoint JSON response

## Build with version
```bash
go build -ldflags "-X main.version=v1.0.0" -o claude_openai_api .
```

## Test plan
- [ ] Verify `--version` flag prints version and exits
- [ ] Verify `/health` includes `version` field
- [ ] Verify `effort` field in request body is passed to Claude CLI as `--effort`
- [ ] Verify omitting `effort` does not add `--effort` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)