### PR TITLE
fix: session viewer blank-page-on-load

### DIFF
--- a/session_store.go
+++ b/session_store.go
@@ -383,8 +383,27 @@ func sessionPageHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Load session events and inline as JSON so content renders immediately
+	// without waiting for WebSocket connection.
+	// Use get() not getOrCreate() to avoid creating empty sessions on page view (DoS vector).
+	var eventsJSON string
+	if entry := globalSessionStore.get(sessionID); entry != nil {
+		events := entry.Events()
+		if data, err := json.Marshal(events); err == nil {
+			eventsJSON = string(data)
+		} else {
+			eventsJSON = "[]"
+		}
+	} else {
+		eventsJSON = "[]"
+	}
+
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	sessionViewerTmpl.Execute(w, struct{ SessionID string }{sessionID})
+	w.Header().Set("Cache-Control", "no-store, private")
+	sessionViewerTmpl.Execute(w, struct {
+		SessionID  string
+		EventsJSON template.JS
+	}{sessionID, template.JS(eventsJSON)})
 }
 
 // sessionListHandler serves a JSON list of all session IDs

--- a/session_viewer.html
+++ b/session_viewer.html
@@ -219,8 +219,14 @@ function renderMarkdown(text) {
   try { return marked.parse(text); } catch(e) { return escHtml(text); }
 }
 
+let currentWs = null;
 function connect() {
+  if (currentWs && (currentWs.readyState === WebSocket.CONNECTING || currentWs.readyState === WebSocket.OPEN)) {
+    return; // Already connected or connecting
+  }
+  wsHistoryDone = false;
   const ws = new WebSocket(wsUrl);
+  currentWs = ws;
   ws.onopen = () => {
     statusDot.classList.add('connected');
     statusLabel.textContent = 'live';
@@ -228,11 +234,20 @@ function connect() {
   ws.onclose = () => {
     statusDot.classList.remove('connected');
     statusLabel.textContent = 'disconnected';
+    currentWs = null;
     setTimeout(connect, 3000);
   };
   ws.onmessage = (e) => {
     const ev = JSON.parse(e.data);
-    if (ev.type === 'history_end') return;
+    if (ev.type === 'history_end') {
+      wsHistoryDone = true;
+      return;
+    }
+    // During WS history replay, skip events already rendered from inline data
+    // but render any newer events (arrived between HTTP snapshot and WS subscribe)
+    if (!wsHistoryDone) {
+      if (lastInlineTs && ev.timestamp && ev.timestamp <= lastInlineTs) return;
+    }
     renderEvent(ev);
   };
 }
@@ -364,13 +379,32 @@ function autoScroll() {
 // Set auto-load hint based on browser language
 (function() {
   const lang = (navigator.language || '').toLowerCase();
-  let text = 'Auto-loading latest messages...';
-  if (lang.startsWith('zh')) text = '自动加载最新消息中...';
-  else if (lang.startsWith('ja')) text = '最新メッセージを自動読み込み中...';
+  let text = 'Waiting for new messages...';
+  if (lang.startsWith('zh')) text = '等待新消息...';
+  else if (lang.startsWith('ja')) text = '新しいメッセージを待機中...';
   autoLoadHint.textContent = text;
 })();
 
+// Render initial events from inline data (no WebSocket dependency)
+const initialEvents = {{.EventsJSON}};
+initialEvents.forEach(ev => renderEvent(ev));
+
+// Track last inline event timestamp for deduplication with WS history
+const lastInlineTs = initialEvents.length > 0
+  ? initialEvents[initialEvents.length - 1].timestamp || ''
+  : '';
+
+// Track whether WebSocket history replay is done
+let wsHistoryDone = false;
+
 connect();
+
+// Reconnect when page is restored from bfcache (back/forward navigation)
+window.addEventListener('pageshow', function(event) {
+  if (event.persisted) {
+    connect();
+  }
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

修复 `/session/{uuid}` 页面偶发的空白问题（需要刷新才能看到内容）。

**根本原因：** 页面内容完全依赖 WebSocket 连接加载历史事件，如果 WS 连接延迟、CDN 脚本加载慢、或页面从浏览器 bfcache 恢复，就会看不到内容。

**修复方案：**
- 服务端将 session 事件内联到 HTML 中，页面加载即渲染，不再等待 WebSocket
- WebSocket 仅负责实时新消息推送
- 通过时间戳去重，避免 HTTP 快照和 WS 订阅之间的事件丢失
- 页面处理改用 `get()` 而非 `getOrCreate()`，防止任意 URL 创建空 session（DoS 防护）
- 添加 `Cache-Control: no-store` 防止代理缓存敏感会话数据
- 添加 bfcache 重连支持，防止浏览器前进/后退时页面失联

## Test plan
- [x] Go build passes
- [x] 页面首次打开即显示历史内容（不依赖 WebSocket）
- [x] WebSocket 连接后实时新消息正常推送
- [x] 自动滚动行为不变
- [x] 访问不存在的 session URL 不会创建空文件

🤖 Generated with [Claude Code](https://claude.com/claude-code)