### PR TITLE
fix: restore auto-scroll after inline event rendering

### DIFF
--- a/session_viewer.html
+++ b/session_viewer.html
@@ -389,6 +389,14 @@ function autoScroll() {
 const initialEvents = {{.EventsJSON}};
 initialEvents.forEach(ev => renderEvent(ev));
 
+// After all inline events rendered, force scroll to bottom so userAtBottom stays true
+if (initialEvents.length > 0) {
+  requestAnimationFrame(() => {
+    window.scrollTo({ top: document.body.scrollHeight, behavior: 'instant' });
+    userAtBottom = true;
+  });
+}
+
 // Track last inline event timestamp for deduplication with WS history
 const lastInlineTs = initialEvents.length > 0
   ? initialEvents[initialEvents.length - 1].timestamp || ''


### PR DESCRIPTION
## Summary
- Fix auto-scroll not working after page load with inlined session events
- Inline events rendered synchronously caused smooth-scroll animations to pile up, setting `userAtBottom=false` before completion
- Added `requestAnimationFrame` + `behavior: 'instant'` scroll after initial render to keep page pinned to bottom for live WS events

## Test plan
- [ ] Open a session viewer page with existing events — page should scroll to bottom on load
- [ ] While viewing, trigger new streaming events — page should auto-scroll to follow new content
- [ ] Scroll up manually, then verify new events show the "scroll to bottom" button instead of forcing scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)