### PR TITLE
feat: 透传 system_prompt_file / allowed_tools / add_dirs / permission_mode

### DIFF
--- a/claude_openai_api.go
+++ b/claude_openai_api.go
@@ -36,11 +36,15 @@ type ChatCompletionRequest struct {
 	Stop          json.RawMessage `json:"stop,omitempty"`
 	Tools         []Tool          `json:"tools,omitempty"`
 	ToolChoice    json.RawMessage `json:"tool_choice,omitempty"`
-	WorkingDir    string            `json:"working_dir,omitempty"`
-	EnvVars       map[string]string `json:"env_vars,omitempty"`
-	MaxTurns      *int              `json:"max_turns,omitempty"`
-	SessionID     string            `json:"session_id,omitempty"`
-	Effort        string            `json:"effort,omitempty"`
+	WorkingDir      string            `json:"working_dir,omitempty"`
+	EnvVars         map[string]string `json:"env_vars,omitempty"`
+	MaxTurns        *int              `json:"max_turns,omitempty"`
+	SessionID       string            `json:"session_id,omitempty"`
+	Effort          string            `json:"effort,omitempty"`
+	SystemPrompt    string            `json:"system_prompt,omitempty"`    // → --system-prompt (相对 WorkingDir 的路径)
+	PermissionMode  string            `json:"permission_mode,omitempty"` // → --permission-mode (缺省 bypassPermissions)
+	AllowedTools    string            `json:"allowed_tools,omitempty"`   // → --allowedTools (逗号分隔, 如 "Read,Bash,Glob")
+	AddDirs         []string          `json:"add_dirs,omitempty"`        // → --add-dir (可多个)
 }
 
 type StreamOptions struct {
@@ -936,12 +940,30 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
 	if systemPrompt != "" {
 		args = append(args, "--append-system-prompt", systemPrompt)
 	}
+	if req.SystemPrompt != "" {
+		args = append(args, "--system-prompt", req.SystemPrompt)
+	}
 	args = append(args, "--model", model)
 	//args = append(args, "--betas", "context-1m-2025-08-07")
 	args = append(args, "--verbose")
 	args = append(args, "--output-format", "stream-json")
 	args = append(args, "--include-partial-messages")
-	args = append(args, "--permission-mode", "bypassPermissions")
+
+	// permission_mode: 调用方可指定, 缺省仍保持 bypassPermissions
+	permMode := "bypassPermissions"
+	if req.PermissionMode != "" {
+		permMode = req.PermissionMode
+	}
+	args = append(args, "--permission-mode", permMode)
+
+	if req.AllowedTools != "" {
+		args = append(args, "--allowedTools", req.AllowedTools)
+	}
+	for _, dir := range req.AddDirs {
+		if dir != "" {
+			args = append(args, "--add-dir", dir)
+		}
+	}
 
 	maxTurns := 200
 	if req.MaxTurns != nil {

--- a/claude_openai_api.go
+++ b/claude_openai_api.go
@@ -41,7 +41,7 @@ type ChatCompletionRequest struct {
 	MaxTurns        *int              `json:"max_turns,omitempty"`
 	SessionID       string            `json:"session_id,omitempty"`
 	Effort          string            `json:"effort,omitempty"`
-	SystemPrompt    string            `json:"system_prompt,omitempty"`    // → --system-prompt (相对 WorkingDir 的路径)
+	SystemPromptFile string           `json:"system_prompt_file,omitempty"` // → --append-system-prompt-file (相对 WorkingDir 的路径)
 	PermissionMode  string            `json:"permission_mode,omitempty"` // → --permission-mode (缺省 bypassPermissions)
 	AllowedTools    string            `json:"allowed_tools,omitempty"`   // → --allowedTools (逗号分隔, 如 "Read,Bash,Glob")
 	AddDirs         []string          `json:"add_dirs,omitempty"`        // → --add-dir (可多个)
@@ -863,6 +863,12 @@ func truncate(s string, maxLen int) string {
 	return s[:maxLen] + "..."
 }
 
+var envVarsLogRedactor = regexp.MustCompile(`"env_vars"\s*:\s*\{[^}]*\}`)
+
+func sanitizeEnvVarsInLog(body string) string {
+	return envVarsLogRedactor.ReplaceAllString(body, `"env_vars":"[REDACTED]"`)
+}
+
 // ---- Handlers ----
 
 func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
@@ -881,10 +887,11 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
 		writeOAIError(w, http.StatusBadRequest, "invalid_request_error", fmt.Sprintf("Failed to read body: %v", err))
 		return
 	}
-	if len(bodyBytes) <= 4096 {
-		log.Printf("Raw request body (%d bytes): %s", len(bodyBytes), string(bodyBytes))
+	logBody := sanitizeEnvVarsInLog(string(bodyBytes))
+	if len(logBody) <= 4096 {
+		log.Printf("Raw request body (%d bytes): %s", len(bodyBytes), logBody)
 	} else {
-		log.Printf("Raw request body (%d bytes): %s...[truncated]", len(bodyBytes), string(bodyBytes[:4096]))
+		log.Printf("Raw request body (%d bytes): %s...[truncated]", len(bodyBytes), logBody[:4096])
 	}
 
 	var req ChatCompletionRequest
@@ -940,8 +947,8 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
 	if systemPrompt != "" {
 		args = append(args, "--append-system-prompt", systemPrompt)
 	}
-	if req.SystemPrompt != "" {
-		args = append(args, "--system-prompt", req.SystemPrompt)
+	if req.SystemPromptFile != "" {
+		args = append(args, "--append-system-prompt-file", req.SystemPromptFile)
 	}
 	args = append(args, "--model", model)
 	//args = append(args, "--betas", "context-1m-2025-08-07")


### PR DESCRIPTION
## Summary

给 `ChatCompletionRequest` 新增 4 个字段，映射到 claude CLI 对应 flag，让调用方可以控制原本硬编码或未暴露的行为。同时把请求体日志里的 `env_vars` 内容屏蔽掉，避免敏感变量泄露到日志。

## Changes

新增请求字段：

| JSON 字段 | claude CLI flag | 说明 |
|---|---|---|
| `system_prompt_file` | `--append-system-prompt-file` | 文件路径（相对 `working_dir`），由 claude CLI 读取文件内容作为系统提示词 |
| `permission_mode` | `--permission-mode` | 调用方可指定；缺省仍为 `bypassPermissions`（保持向后兼容） |
| `allowed_tools` | `--allowedTools` | 逗号分隔，例如 `"Read,Bash,Glob"` |
| `add_dirs` | `--add-dir` | 字符串数组，支持多次追加 |

原先 `--permission-mode bypassPermissions` 是硬编码，现在改为有缺省值、可覆盖。

### 日志脱敏

新增 `sanitizeEnvVarsInLog`：打印 raw request body 时把 `env_vars` 整个对象替换为 `"env_vars":"[REDACTED]"`，避免 API key 等敏感变量落盘到日志。

## Test plan

- [ ] 发送不带任何新字段的请求，行为和原来一致（permission_mode 仍为 bypassPermissions）
- [ ] 发送带 `system_prompt_file` 的请求，验证 claude CLI 能读取到文件内容作为系统提示词
- [ ] 发送带 `allowed_tools: "Read,Bash"` 的请求，验证 CLI 只能使用这两个工具
- [ ] 发送带 `add_dirs: ["/tmp/a", "/tmp/b"]` 的请求，验证 `--add-dir` 被多次追加
- [ ] 发送带 `permission_mode: "default"` 的请求，验证 permission_mode 被正确覆盖
- [ ] 发送带 `env_vars` 的请求，检查日志输出中 `env_vars` 值被替换为 `[REDACTED]`