### PR TITLE
feat: add 30s SSE heartbeat to detect stuck upstreams

### DIFF
--- a/claude_openai_api.go
+++ b/claude_openai_api.go
@@ -21,7 +21,7 @@ import (
 	"time"
 )
 
-var version = "1.0.0"
+var version = "1.0.1"
 
 // ---- OpenAI-compatible request/response types ----
 
@@ -1296,6 +1296,12 @@ func handleStreamResponse(w http.ResponseWriter, r *http.Request, args []string,
 	fmt.Fprintf(w, ": ping\n\n")
 	flusher.Flush()
 
+	// Periodic SSE heartbeat so idle clients (aiohttp sock_read) can detect stuck upstreams.
+	// Claude CLI can go silent for minutes on a blocked tool call, which otherwise makes
+	// the client wait for the full aiohttp `total` timeout.
+	heartbeatTicker := time.NewTicker(30 * time.Second)
+	defer heartbeatTicker.Stop()
+
 	var streamDeltaSent bool // true if we've sent any stream_event deltas
 	var streamUsage *UsageInfo // captured from result event for session logging
 	seenToolNames := map[string]bool{} // deduplicate tool_call chunks across both detection paths
@@ -1341,7 +1347,22 @@ func handleStreamResponse(w http.ResponseWriter, r *http.Request, args []string,
 	}
 	toolBlocks := map[int]*toolBlock{}
 
-	for line := range lines {
+processLines:
+	for {
+		var line string
+		var ok bool
+		select {
+		case <-r.Context().Done():
+			return
+		case <-heartbeatTicker.C:
+			fmt.Fprintf(w, ": keepalive\n\n")
+			flusher.Flush()
+			continue
+		case line, ok = <-lines:
+			if !ok {
+				break processLines
+			}
+		}
 		if line == "" {
 			continue
 		}
@@ -1675,6 +1696,10 @@ func handleBufferedStreamResponse(w http.ResponseWriter, r *http.Request, args [
 	fmt.Fprintf(w, ": ping\n\n")
 	flusher.Flush()
 
+	// Periodic SSE heartbeat so idle clients (aiohttp sock_read) can detect stuck upstreams.
+	heartbeatTicker := time.NewTicker(30 * time.Second)
+	defer heartbeatTicker.Stop()
+
 	// Track text and native tool_use blocks from Claude CLI's stream.
 	var fullText strings.Builder
 	var filter toolCallFilter
@@ -1689,7 +1714,22 @@ func handleBufferedStreamResponse(w http.ResponseWriter, r *http.Request, args [
 	// AskUserQuestion tracking
 	var askUserIdx int = -1 // index of AskUserQuestion content block, -1 if none
 
-	for line := range lines {
+processLines:
+	for {
+		var line string
+		var ok bool
+		select {
+		case <-r.Context().Done():
+			return
+		case <-heartbeatTicker.C:
+			fmt.Fprintf(w, ": keepalive\n\n")
+			flusher.Flush()
+			continue
+		case line, ok = <-lines:
+			if !ok {
+				break processLines
+			}
+		}
 		if line == "" {
 			continue
 		}


### PR DESCRIPTION
## Summary

Add a periodic 30-second SSE heartbeat (`: keepalive\n\n`) to both streaming handlers so idle clients can distinguish "upstream is alive, tool is just running long" from "Claude CLI stuck / process hung" — without waiting for the full `sse_timeout_seconds`.

## Motivation

Without a heartbeat, if the Claude CLI child process goes silent on a blocked tool call (Bash waiting on network, stuck subprocess, etc.), the SSE stream produces zero bytes and clients have no way to detect the stall except by waiting the full `total` timeout. In our deployment this meant a client's `aiohttp.ClientTimeout(sock_read=3600)` would wait a whole hour before giving up, and the upstream app state (choice sessions, etc.) stayed locked for that entire window.

After this change, clients can safely set `sock_read=60` and catch real stalls within a minute, while long-running tools still see regular keepalives.

## Changes

- `handleStreamResponse` and `handleBufferedStreamResponse`: `for line := range lines` rewritten as a labeled `for`/`select` that merges the existing `lines` channel with a `time.Ticker`. All SSE writes remain in the main goroutine (no mutex needed).
- Added `<-r.Context().Done(): return` fast-path so the main loop exits immediately on client disconnect, rather than waiting for the kill-claude goroutine to close the upstream stdout.
- Bump version `1.0.0` → `1.0.1`.

## Notes

- `: keepalive\n\n` is an SSE comment line — compliant clients ignore it and do not treat it as a data event.
- Heartbeat interval (30s) is hardcoded for now; could be made configurable if needed.
- Already deployed and verified across 11 production instances (6 chroot + 5 nspawn) — all healthy, serving real traffic on v1.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)