### PR TITLE
fix(relay-codex): stage uploads inside working_dir so codex can read them

### DIFF
--- a/cmd/relay-codex/codex.go
+++ b/cmd/relay-codex/codex.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -13,6 +14,25 @@ import (
 	"clawrelay-api/pkg/openai"
 	"clawrelay-api/pkg/proc"
 )
+
+// resolveCodexUploadDir decides where decoded attachments for a codex turn are
+// written. Unlike claude (which runs with --permission-mode bypassPermissions
+// and will read any absolute path), codex refuses to touch files outside its
+// working dir even under --dangerously-bypass-approvals-and-sandbox. So when the
+// caller supplies a working_dir we stage uploads INSIDE it, under a git-ignored
+// .relay_uploads/<session> subdir where codex can read them. With no working_dir
+// we fall back to the relay's own sessions tree (the legacy behavior). Returns
+// "" when there is no session — attachments.ExtractAndSave then uses a fresh
+// /tmp file the caller is expected to clean up.
+func resolveCodexUploadDir(workingDir, sessionsAbsDir, sessionID string) string {
+	if sessionID == "" {
+		return ""
+	}
+	if workingDir != "" {
+		return filepath.Join(workingDir, ".relay_uploads", sessionID)
+	}
+	return filepath.Join(sessionsAbsDir, sessionID, "files")
+}
 
 // cleanEnv mirrors the Claude relay's helper but strips CODEX_* job-control
 // vars so a relay running inside another codex session doesn't confuse the

--- a/cmd/relay-codex/codex_test.go
+++ b/cmd/relay-codex/codex_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -105,6 +106,52 @@ func TestBuildCodexInputNoSystemMessages(t *testing.T) {
 	in := buildCodexInput(req, "codex/gpt-5.4", "", "")
 	if strings.Contains(in.Stdin, "system_rules") {
 		t.Fatalf("expected no system_rules block when no system message; got: %s", in.Stdin)
+	}
+}
+
+// TestResolveCodexUploadDir locks in the fix for the codex file-permission bug:
+// codex refuses to read attachments outside its working dir, so when a
+// working_dir is supplied uploads must be staged INSIDE it. With no working_dir
+// we fall back to the relay's own sessions tree, and with no session there is no
+// stable dir (ephemeral /tmp staging in attachments.ExtractAndSave).
+func TestResolveCodexUploadDir(t *testing.T) {
+	tests := []struct {
+		name           string
+		workingDir     string
+		sessionsAbsDir string
+		sessionID      string
+		want           string
+	}{
+		{
+			name:           "working dir present stages inside cwd",
+			workingDir:     "/data/skills/testa",
+			sessionsAbsDir: "/home/claude10/sessions",
+			sessionID:      "sess-1",
+			want:           filepath.Join("/data/skills/testa", ".relay_uploads", "sess-1"),
+		},
+		{
+			name:           "no working dir falls back to sessions tree",
+			workingDir:     "",
+			sessionsAbsDir: "/home/claude10/sessions",
+			sessionID:      "sess-1",
+			want:           filepath.Join("/home/claude10/sessions", "sess-1", "files"),
+		},
+		{
+			name:           "no session id means ephemeral tmp staging",
+			workingDir:     "/data/skills/testa",
+			sessionsAbsDir: "/home/claude10/sessions",
+			sessionID:      "",
+			want:           "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveCodexUploadDir(tt.workingDir, tt.sessionsAbsDir, tt.sessionID)
+			if got != tt.want {
+				t.Fatalf("resolveCodexUploadDir(%q,%q,%q) = %q, want %q",
+					tt.workingDir, tt.sessionsAbsDir, tt.sessionID, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cmd/relay-codex/main.go
+++ b/cmd/relay-codex/main.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -30,7 +31,7 @@ import (
 	"clawrelay-api/pkg/sessions"
 )
 
-var version = "1.1.4"
+var version = "1.1.5"
 
 var defaultModel = "codex/gpt-5.5"
 
@@ -100,10 +101,19 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
 			"codex uses its own native tool harness (shell, file edits, web_search, etc.)", len(req.Tools))
 	}
 
-	// Per-session attachment + thread-binding directory.
-	var sessionDir string
-	if req.SessionID != "" {
-		sessionDir = sessionStore.AbsDir() + "/" + req.SessionID + "/files"
+	// Per-session attachment directory. Codex (unlike claude's bypassPermissions)
+	// won't read files outside its working dir, so uploads must be staged INSIDE
+	// it — see resolveCodexUploadDir. We git-ignore the staging root so the bot's
+	// working-dir git status stays clean, and remove this turn's files when the
+	// request finishes (codex resume only resends the latest message, so no
+	// cross-turn dedup is lost).
+	sessionDir := resolveCodexUploadDir(req.WorkingDir, sessionStore.AbsDir(), req.SessionID)
+	if sessionDir != "" && req.WorkingDir != "" {
+		uploadsRoot := filepath.Join(req.WorkingDir, ".relay_uploads")
+		if err := os.MkdirAll(uploadsRoot, 0755); err == nil {
+			_ = os.WriteFile(filepath.Join(uploadsRoot, ".gitignore"), []byte("*\n"), 0644)
+		}
+		defer os.RemoveAll(sessionDir)
 	}
 
 	// Look up an existing codex thread for this client session — this is the


### PR DESCRIPTION
## Problem

codex-backed requests fail to read uploaded files (PDF / CSV / etc.), with codex reporting the file is *outside the workspace / no permission* — while the claude backend handles the same uploads fine.

**Root cause:** `relay-codex` writes decoded attachments to the relay's own `<sessions>/<id>/files/` directory, which is **outside** the codex working dir (`req.working_dir`). The codex CLI refuses to read files outside its cwd **even with `--dangerously-bypass-approvals-and-sandbox`** (the default when no `permission_mode` is set). By contrast `relay-claude` runs with `--permission-mode bypassPermissions`, and claude reads any absolute path — which is why only the codex backend was affected. Attachment staging, the `[File: <path>]` injection, and the cwd are otherwise identical between the two relays.

## Fix

Stage codex attachments **inside the working dir** so codex can read them:

- New `resolveCodexUploadDir(workingDir, sessionsAbsDir, sessionID)`: when a `working_dir` is supplied, uploads go to `<working_dir>/.relay_uploads/<session>/`; otherwise it falls back to the relay's sessions tree (legacy behavior). No session → `""` (ephemeral `/tmp` staging, unchanged).
- The staging root gets a `.gitignore` (`*`) so the working dir's git status stays clean, and each turn's files are removed when the request finishes (`os.RemoveAll`). codex resume only resends the latest user message, so no cross-turn dedup is lost.
- `pkg/attachments/attach.go` is untouched (shared with relay-claude) — **zero impact on the claude backend**.
- Bumped relay-codex `1.1.4 → 1.1.5`.

Deliberately **not** using codex `--add-dir` to whitelist the sessions dir: `codex exec resume` rejects `--add-dir` / `-s`, so multi-turn conversations carrying attachments would break. Staging into cwd is robust for both the sandbox-enforced and the model-self-restricted cases.

## Tests

- Added `TestResolveCodexUploadDir` (table-driven: working_dir / no-working_dir / no-session).
- `go build ./...` and `go test ./cmd/relay-codex/` pass.
- End-to-end verified against a live `relay-codex` (1.1.5): uploaded a text file with a unique marker via `working_dir` + `file_url`; codex read the content back correctly, and the staging dir was cleaned up afterwards (only `.gitignore` remained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
