### PR TITLE
fix(relay-codex): resume thread usage 跨轮差分，修累计重复计费

### DIFF
--- a/cmd/relay-codex/main.go
+++ b/cmd/relay-codex/main.go
@@ -31,7 +31,7 @@ import (
 	"clawrelay-api/pkg/sessions"
 )
 
-var version = "1.1.5"
+var version = "1.1.6"
 
 var defaultModel = "codex/gpt-5.5"
 
@@ -52,6 +52,7 @@ var allowedOrigins = []string{
 var (
 	sessionStore *sessions.Store
 	threads      *threadMap
+	meter        *usageMeter
 	stats        = openai.NewStats()
 )
 
@@ -222,6 +223,7 @@ func main() {
 	sessionStore = sessions.New(*sessionsDir)
 	sessionStore.StartCleanup(72*time.Hour, 1*time.Hour)
 	threads = newThreadMap(sessionStore.AbsDir())
+	meter = newUsageMeter(sessionStore.AbsDir())
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/chat/completions", chatCompletionsHandler)

--- a/cmd/relay-codex/stream.go
+++ b/cmd/relay-codex/stream.go
@@ -161,9 +161,7 @@ processLines:
 		case "thread.started":
 			threadIDSeen = ev.ThreadID
 			log.Printf("[CODEX] thread_id=%s session_id=%s", ev.ThreadID, sessionID)
-			if sessionID != "" {
-				threads.Set(sessionID, ev.ThreadID)
-			}
+			rebindThread(sessionID, ev.ThreadID)
 
 		case "turn.started":
 			// no-op
@@ -208,9 +206,9 @@ processLines:
 
 		case "turn.completed":
 			if ev.Usage != nil {
-				input, output, cacheRead := mapUsage(ev.Usage)
+				input, output, cacheRead := turnUsage(sessionID, ev.Usage)
 				stats.Record(model, input, output, 0, cacheRead, 0)
-				log.Printf("Token usage: model=%s input=%d output=%d cache_read=%d (codex)",
+				log.Printf("Token usage: model=%s input=%d output=%d cache_read=%d (codex, per-turn)",
 					model, input, output, cacheRead)
 				streamUsage = openai.BuildUsageInfo(input, output, cacheRead, 0)
 			}
@@ -223,9 +221,11 @@ processLines:
 			}
 			log.Printf("[CODEX ERROR] %s", errMsg)
 			// If a resume failed because the thread is gone, drop the
-			// stale binding so the next turn starts fresh.
+			// stale binding so the next turn starts fresh. The usage baseline
+			// is tied to that thread's cumulative counter, so drop it too.
 			if sessionID != "" && input.IsResume && strings.Contains(errMsg, "session") {
 				threads.Forget(sessionID)
+				meter.Forget(sessionID)
 			}
 			textDelta("\n\n[codex error] " + errMsg)
 			emittedAnyContent = true
@@ -293,9 +293,7 @@ func handleNonStreamResponse(w http.ResponseWriter, r *http.Request, input codex
 		switch ev.Type {
 		case "thread.started":
 			threadIDSeen = ev.ThreadID
-			if sessionID != "" {
-				threads.Set(sessionID, ev.ThreadID)
-			}
+			rebindThread(sessionID, ev.ThreadID)
 		case "item.completed":
 			if ev.Item == nil {
 				continue
@@ -305,7 +303,7 @@ func handleNonStreamResponse(w http.ResponseWriter, r *http.Request, input codex
 			}
 		case "turn.completed":
 			if ev.Usage != nil {
-				inp, out, cr := mapUsage(ev.Usage)
+				inp, out, cr := turnUsage(sessionID, ev.Usage)
 				stats.Record(model, inp, out, 0, cr, 0)
 				usage = openai.BuildUsageInfo(inp, out, cr, 0)
 			}
@@ -316,6 +314,7 @@ func handleNonStreamResponse(w http.ResponseWriter, r *http.Request, input codex
 			}
 			if sessionID != "" && input.IsResume && strings.Contains(errorMsg, "session") {
 				threads.Forget(sessionID)
+				meter.Forget(sessionID)
 			}
 		}
 	}
@@ -351,6 +350,46 @@ func handleNonStreamResponse(w http.ResponseWriter, r *http.Request, input codex
 	json.NewEncoder(w).Encode(resp)
 
 	_ = threadIDSeen
+}
+
+// rebindThread records the codex thread_id for a session. If codex rotated to a
+// DIFFERENT thread (a resume that silently started a fresh thread instead of
+// erroring), the old usage baseline is foreign — the new thread's cumulative
+// counter restarts from zero — so drop it before rebinding, otherwise the next
+// turn would diff against a stale baseline and mis-bill. No-op when meter is nil
+// (handler invoked without main()'s init, e.g. tests).
+//
+// The Get-then-Set is not atomic, but turns for one session are effectively
+// serial (a conversation is request/response, and codex can't resume one thread
+// concurrently), so the rotation-during-concurrent-turn window is not a concern
+// in practice.
+func rebindThread(sessionID, threadID string) {
+	if sessionID == "" || threadID == "" {
+		return
+	}
+	if meter != nil {
+		if prev := threads.Get(sessionID); prev != "" && prev != threadID {
+			meter.Forget(sessionID)
+		}
+	}
+	threads.Set(sessionID, threadID)
+}
+
+// turnUsage resolves one turn's reportable (input, output, cache_read) from
+// codex's reported usage. codex reports thread-cumulative totals on resume, so
+// the meter diffs against the session's baseline to recover this turn's figure;
+// without that diff a resumed thread's usage climbs monotonically and every turn
+// re-counts all earlier turns.
+//
+// Assumes exactly one turn.completed per request (codex's `exec` contract): each
+// call advances the persisted baseline, so multiple turn.completed in one request
+// would each bill their own delta correctly but only the last would reach the
+// client's usage chunk.
+func turnUsage(sessionID string, u *codexUsage) (input, output, cacheRead int) {
+	if meter == nil { // defensive: handler invoked without main()'s init (tests)
+		return mapUsage(u)
+	}
+	return meter.perTurn(sessionID, *u)
 }
 
 // mapUsage converts codex's usage shape to the (input, output, cache_read)

--- a/cmd/relay-codex/usage_meter.go
+++ b/cmd/relay-codex/usage_meter.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// usageMeter converts codex's per-thread *cumulative* usage into per-turn
+// reportable usage.
+//
+// Why this exists: codex reports usage on every `turn.completed`, but the
+// figures are running totals for the whole thread, not the single turn. Because
+// we resume the same thread across requests (see threadMap), a long session's
+// raw input/output/cached counts climb monotonically — feeding them straight
+// into the chat log double-counts every earlier turn. In production (2026-06) a
+// 78-turn session inflated input ~40x (single turn reached 5.5M, far past any
+// model context window) before this was caught.
+//
+// Unlike relay-claude's in-process cumulativeMeter, the codex cumulative counter
+// lives in the *thread*, which outlives the relay process — threadMap persists
+// thread_id to disk and resumes it after restarts. So the baseline has to be
+// persisted per session too: otherwise a relay restart would diff against a zero
+// baseline and re-bill the whole thread once. The baseline file sits next to
+// codex_thread.txt under the session dir, so session cleanup reaps both
+// together — thread gone ⇒ baseline gone ⇒ next thread starts from zero on both
+// sides.
+//
+// Known accepted cost: the FIRST turn after this build is first deployed onto an
+// already-live thread has no baseline file yet, so it diffs against zero and
+// bills that thread's accumulated total as one turn (a one-off inflation per
+// active session, bounded to the backlog at deploy time). There is no way to
+// recover the true baseline without a prior turn, so this is accepted rather
+// than guarded; see TestUsageMeterEmptyBaselineInflatesOnce which pins it.
+
+// meterBaseline is the per-session high-water mark of the *reportable* cumulative
+// usage — already split into uncached-input / cache-read / output via mapUsage.
+// Diffing the derived split (rather than codex's raw total+cached, then
+// recombining) is what keeps the input/cache_read attribution correct when the
+// cached subset and the total move by different amounts across turns.
+type meterBaseline struct {
+	Uncached  int `json:"uncached_input_tokens"`
+	CacheRead int `json:"cache_read_tokens"`
+	Output    int `json:"output_tokens"`
+}
+
+type usageMeter struct {
+	mu      sync.Mutex
+	memory  map[string]meterBaseline // session_id → cumulative high-water baseline
+	rootDir string
+}
+
+func newUsageMeter(rootDir string) *usageMeter {
+	return &usageMeter{
+		memory:  make(map[string]meterBaseline),
+		rootDir: rootDir,
+	}
+}
+
+// deriveBaseline maps codex's raw cumulative usage to the reportable cumulative
+// split, reusing mapUsage so the total→(uncached,cacheRead) rule lives in one
+// place (and handles the malformed cached>total case the same way).
+func deriveBaseline(u codexUsage) meterBaseline {
+	input, output, cacheRead := mapUsage(&u)
+	return meterBaseline{Uncached: input, CacheRead: cacheRead, Output: output}
+}
+
+// perTurn returns this turn's reportable (input, output, cacheRead) given codex's
+// cumulative snapshot `cur`. With no session id there is no thread reuse, so the
+// snapshot is already per-turn and is returned as-is (just split).
+//
+// Otherwise it diffs the derived cumulative split against the session's stored
+// baseline, flooring each field at zero, and advances the baseline to the
+// per-field high-water mark. Flooring + high-water (rather than a "cur < last ⇒
+// emit the whole cur as one turn" reset) keeps totals correct under the two ways
+// last and cur can disagree WITHOUT a genuine counter reset:
+//
+//   - Out-of-order completion of two concurrent same-session turns: the earlier
+//     (smaller) snapshot floors to 0 instead of re-billing its full cumulative,
+//     and the high-water baseline stops it dragging the baseline backwards, so
+//     the running sum stays exact regardless of completion order.
+//   - One field dipping while others climb: we never bill a climbing field's
+//     entire cumulative just because a different field regressed.
+//
+// A genuine counter reset (a different/new thread) is handled upstream: thread
+// rotation calls Forget, zeroing the baseline so cur passes through as the turn.
+func (m *usageMeter) perTurn(sessionID string, cur codexUsage) (input, output, cacheRead int) {
+	b := deriveBaseline(cur)
+	if sessionID == "" {
+		return b.Uncached, b.Output, b.CacheRead
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	last, ok := m.memory[sessionID]
+	if !ok {
+		last = m.load(sessionID) // read-through from disk on first turn after a restart
+	}
+
+	input = max(b.Uncached-last.Uncached, 0)
+	output = max(b.Output-last.Output, 0)
+	cacheRead = max(b.CacheRead-last.CacheRead, 0)
+
+	// Advance the baseline to the per-field high-water mark so an out-of-order
+	// smaller snapshot can't pull it back and double-bill the next turn.
+	hi := meterBaseline{
+		Uncached:  max(b.Uncached, last.Uncached),
+		CacheRead: max(b.CacheRead, last.CacheRead),
+		Output:    max(b.Output, last.Output),
+	}
+	m.memory[sessionID] = hi
+	m.store(sessionID, hi)
+	return input, output, cacheRead
+}
+
+// Forget drops a session's baseline. Called alongside threadMap.Forget when the
+// codex thread is gone or rotated — the replacement thread restarts its
+// cumulative counter from zero, so the baseline must too.
+func (m *usageMeter) Forget(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	m.mu.Lock()
+	delete(m.memory, sessionID)
+	m.mu.Unlock()
+	_ = os.Remove(m.path(sessionID))
+}
+
+func (m *usageMeter) load(sessionID string) meterBaseline {
+	var b meterBaseline
+	data, err := os.ReadFile(m.path(sessionID))
+	if err != nil {
+		return b // no baseline yet (new session, or reaped by cleanup) — zero is correct
+	}
+	if err := json.Unmarshal(data, &b); err != nil {
+		// A corrupt baseline must NOT silently read as zero — that would re-bill
+		// the thread's whole cumulative as one turn (the very inflation this
+		// meter prevents). store() writes atomically so this should be
+		// unreachable barring external tampering/FS damage; surface it loudly so
+		// the one-off over-count is at least detectable.
+		log.Printf("[usageMeter] corrupt baseline %s: %v — treating as empty (turn may over-count once)", m.path(sessionID), err)
+		return meterBaseline{}
+	}
+	return b
+}
+
+func (m *usageMeter) store(sessionID string, b meterBaseline) {
+	dir := filepath.Join(m.rootDir, sessionID)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		log.Printf("[usageMeter] mkdir %s: %v — baseline not persisted, may re-bill after restart", dir, err)
+		return
+	}
+	data, err := json.Marshal(b)
+	if err != nil {
+		log.Printf("[usageMeter] marshal baseline for %s: %v", sessionID, err)
+		return
+	}
+	// Atomic write: a crash mid-write would otherwise leave a truncated file that
+	// load() can't parse. tmp+rename within the same dir is atomic on POSIX.
+	tmp := m.path(sessionID) + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		log.Printf("[usageMeter] write %s: %v — baseline not persisted, may re-bill after restart", tmp, err)
+		return
+	}
+	if err := os.Rename(tmp, m.path(sessionID)); err != nil {
+		log.Printf("[usageMeter] rename %s: %v — baseline not persisted", tmp, err)
+		_ = os.Remove(tmp)
+	}
+}
+
+func (m *usageMeter) path(sessionID string) string {
+	return filepath.Join(m.rootDir, sessionID, "codex_usage.json")
+}

--- a/cmd/relay-codex/usage_meter_test.go
+++ b/cmd/relay-codex/usage_meter_test.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// codex reports thread-cumulative usage on every turn; the meter must return
+// per-turn reportable figures (uncached input, output, cache_read), not totals.
+func TestUsageMeterDiffsCumulative(t *testing.T) {
+	m := newUsageMeter(t.TempDir())
+
+	// turn1 cumulative: total=100, cached=40, out=10 → uncached input=60.
+	in, out, cr := m.perTurn("s1", codexUsage{InputTokens: 100, CachedInputTokens: 40, OutputTokens: 10})
+	if in != 60 || out != 10 || cr != 40 {
+		t.Fatalf("turn1 = in:%d out:%d cr:%d, want 60/10/40 (first turn, zero baseline)", in, out, cr)
+	}
+
+	// turn2 cumulative: total=260, cached=90, out=35 → uncached=170; per-turn
+	// delta vs turn1's split: input 170-60=110, cache_read 90-40=50, out 35-10=25.
+	in, out, cr = m.perTurn("s1", codexUsage{InputTokens: 260, CachedInputTokens: 90, OutputTokens: 35})
+	if in != 110 || out != 25 || cr != 50 {
+		t.Fatalf("turn2 = in:%d out:%d cr:%d, want 110/25/50 (per-turn delta)", in, out, cr)
+	}
+}
+
+// An empty session id means no thread reuse — the snapshot is already per-turn,
+// just split into (uncached input, output, cache_read).
+func TestUsageMeterPassThroughNoSession(t *testing.T) {
+	m := newUsageMeter(t.TempDir())
+	in, out, cr := m.perTurn("", codexUsage{InputTokens: 500, CachedInputTokens: 200, OutputTokens: 50})
+	if in != 300 || out != 50 || cr != 200 {
+		t.Fatalf("no-session = in:%d out:%d cr:%d, want 300/50/200 (split, not diffed)", in, out, cr)
+	}
+}
+
+// A regression (smaller snapshot than the baseline) within a thread is anomalous
+// — every field must floor to zero, NOT emit the whole cur as one turn — and the
+// baseline must hold its high-water mark so a later real turn still diffs right.
+func TestUsageMeterFloorsRegression(t *testing.T) {
+	m := newUsageMeter(t.TempDir())
+	m.perTurn("s1", codexUsage{InputTokens: 1000, CachedInputTokens: 400, OutputTokens: 100}) // baseline derived {600,400,100}
+
+	in, out, cr := m.perTurn("s1", codexUsage{InputTokens: 120, CachedInputTokens: 30, OutputTokens: 12})
+	if in != 0 || out != 0 || cr != 0 {
+		t.Fatalf("regression = in:%d out:%d cr:%d, want all-zero (floored, not raw cur)", in, out, cr)
+	}
+
+	// Baseline must still be the high-water {600,400,100}, so the next real turn
+	// diffs against it. cur derived {660,440,110} → delta 60/10/40.
+	in, out, cr = m.perTurn("s1", codexUsage{InputTokens: 1100, CachedInputTokens: 440, OutputTokens: 110})
+	if in != 60 || out != 10 || cr != 40 {
+		t.Fatalf("after regression, next = in:%d out:%d cr:%d, want 60/10/40", in, out, cr)
+	}
+}
+
+// Two concurrent same-session turns completing OUT OF ORDER (larger cumulative
+// lands first) must still bill the correct total — the earlier snapshot floors
+// to zero, the high-water baseline keeps the sum exact regardless of order.
+func TestUsageMeterConcurrentOutOfOrder(t *testing.T) {
+	m := newUsageMeter(t.TempDir())
+	m.perTurn("s1", codexUsage{InputTokens: 1000, CachedInputTokens: 400, OutputTokens: 100}) // baseline {600,400,100}
+
+	in1, out1, cr1 := m.perTurn("s1", codexUsage{InputTokens: 1400, CachedInputTokens: 520, OutputTokens: 140}) // larger first
+	in2, out2, cr2 := m.perTurn("s1", codexUsage{InputTokens: 1200, CachedInputTokens: 460, OutputTokens: 120}) // smaller second
+
+	// Totals must equal high-water {880,520,140} minus baseline {600,400,100}.
+	if in1+in2 != 280 || out1+out2 != 40 || cr1+cr2 != 120 {
+		t.Fatalf("out-of-order totals = in:%d out:%d cr:%d, want 280/40/120", in1+in2, out1+out2, cr1+cr2)
+	}
+	if in2 != 0 || out2 != 0 || cr2 != 0 {
+		t.Fatalf("the smaller out-of-order snapshot = in:%d out:%d cr:%d, want all-zero (floored)", in2, out2, cr2)
+	}
+}
+
+// Deriving the split BEFORE diffing (not diffing raw total/cached then
+// recombining) keeps attribution correct when the cached subset and the total
+// move by different amounts: here total climbs while the cached cumulative dips,
+// and the whole increment must land in input — none of it lost.
+func TestUsageMeterDerivesBeforeDiff(t *testing.T) {
+	m := newUsageMeter(t.TempDir())
+	m.perTurn("s1", codexUsage{InputTokens: 100, CachedInputTokens: 80, OutputTokens: 10}) // baseline derived {uncached:20, cr:80, out:10}
+
+	// cur derived {uncached:190, cr:60, out:25}. input = 190-20 = 170; cache_read
+	// floors (60<80) to 0; output 25-10 = 15.
+	in, out, cr := m.perTurn("s1", codexUsage{InputTokens: 250, CachedInputTokens: 60, OutputTokens: 25})
+	if in != 170 || out != 15 || cr != 0 {
+		t.Fatalf("derive-before-diff = in:%d out:%d cr:%d, want 170/15/0 (no input lost to the cached dip)", in, out, cr)
+	}
+}
+
+// A single derived field dipping while others climb must floor only that field.
+func TestUsageMeterSingleFieldRegression(t *testing.T) {
+	m := newUsageMeter(t.TempDir())
+	m.perTurn("s1", codexUsage{InputTokens: 1000, CachedInputTokens: 900, OutputTokens: 100}) // derived {uncached:100, cr:900, out:100}
+
+	// cur derived {uncached:100, cr:910, out:90}: input delta 0, cache_read +10,
+	// output floors (90<100) to 0.
+	in, out, cr := m.perTurn("s1", codexUsage{InputTokens: 1010, CachedInputTokens: 910, OutputTokens: 90})
+	if in != 0 || out != 0 || cr != 10 {
+		t.Fatalf("single-field regression = in:%d out:%d cr:%d, want 0/0/10 (only output floored)", in, out, cr)
+	}
+}
+
+// The codex thread (and its cumulative counter) outlives the relay process, so
+// the baseline must survive a restart — a fresh meter reads it back from disk
+// and keeps diffing instead of re-counting the whole thread.
+func TestUsageMeterPersistsAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	m1 := newUsageMeter(dir)
+	m1.perTurn("s1", codexUsage{InputTokens: 300, CachedInputTokens: 100, OutputTokens: 30}) // baseline derived {200,100,30}
+
+	m2 := newUsageMeter(dir) // simulate relay restart: in-memory map is empty
+	in, out, cr := m2.perTurn("s1", codexUsage{InputTokens: 420, CachedInputTokens: 130, OutputTokens: 44})
+	if in != 90 || out != 14 || cr != 30 {
+		t.Fatalf("after restart = in:%d out:%d cr:%d, want 90/14/30 (baseline loaded from disk)", in, out, cr)
+	}
+}
+
+// Deploying this build onto an already-live thread leaves no baseline file, so
+// the first turn bills the whole accumulated cumulative once. This is an accepted
+// one-off cost (we can't recover the true baseline without a prior turn); pin it
+// so the behavior is intentional and visible, and confirm it self-corrects after.
+func TestUsageMeterEmptyBaselineInflatesOnce(t *testing.T) {
+	m := newUsageMeter(t.TempDir())
+
+	// derived uncached input = 5_000_000 - 2_000_000 = 3_000_000.
+	in, _, cr := m.perTurn("live", codexUsage{InputTokens: 5_000_000, CachedInputTokens: 2_000_000, OutputTokens: 100_000})
+	if in != 3_000_000 || cr != 2_000_000 {
+		t.Fatalf("first-turn-after-deploy = in:%d cr:%d, want 3_000_000/2_000_000 (accepted one-off)", in, cr)
+	}
+	in, _, _ = m.perTurn("live", codexUsage{InputTokens: 5_050_000, CachedInputTokens: 2_010_000, OutputTokens: 101_000})
+	if in != 40_000 { // derived 3_040_000 - 3_000_000
+		t.Fatalf("second turn input = %d, want 40_000 (self-corrected)", in)
+	}
+}
+
+// A corrupt/truncated baseline file (should be unreachable given atomic writes,
+// but possible via FS damage/tampering) must not panic and must not be read as a
+// partial number — it falls back to empty and recovers on the next turn.
+func TestUsageMeterCorruptBaseline(t *testing.T) {
+	dir := t.TempDir()
+	sessDir := filepath.Join(dir, "s1")
+	if err := os.MkdirAll(sessDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessDir, "codex_usage.json"), []byte("{\"uncached_input_tokens\":12"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newUsageMeter(dir)
+	in, _, _ := m.perTurn("s1", codexUsage{InputTokens: 300, CachedInputTokens: 100, OutputTokens: 30})
+	if in != 200 { // treated as empty baseline → derived uncached 300-100
+		t.Fatalf("corrupt baseline input = %d, want 200 (treated as empty, not partial)", in)
+	}
+	// The atomic store should have replaced the corrupt file with a valid one.
+	in, _, _ = m.perTurn("s1", codexUsage{InputTokens: 360, CachedInputTokens: 130, OutputTokens: 44})
+	if in != 30 { // derived uncached 230 - baseline 200
+		t.Fatalf("post-recovery input = %d, want 30", in)
+	}
+}
+
+// Forget drops the baseline so the replacement thread starts from zero.
+func TestUsageMeterForget(t *testing.T) {
+	dir := t.TempDir()
+	m := newUsageMeter(dir)
+	m.perTurn("s1", codexUsage{InputTokens: 500, CachedInputTokens: 200, OutputTokens: 50})
+
+	m.Forget("s1")
+
+	fresh := newUsageMeter(dir) // no in-memory cache; must not find a stale baseline
+	in, out, cr := fresh.perTurn("s1", codexUsage{InputTokens: 90, CachedInputTokens: 20, OutputTokens: 9})
+	if in != 70 || out != 9 || cr != 20 { // derived split of the raw snapshot, zero baseline
+		t.Fatalf("after Forget = in:%d out:%d cr:%d, want 70/9/20 (baseline cleared)", in, out, cr)
+	}
+}
+
+// When codex rotates a session to a different thread_id (resume silently started
+// a new thread), rebindThread must drop the usage baseline — the new thread's
+// counter restarts at zero, so the old baseline is foreign. A rebind to the SAME
+// thread must NOT drop it.
+func TestRebindThreadForgetsOnRotation(t *testing.T) {
+	dir := t.TempDir()
+	oldThreads, oldMeter := threads, meter
+	threads = newThreadMap(dir)
+	meter = newUsageMeter(dir)
+	defer func() { threads, meter = oldThreads, oldMeter }()
+
+	threads.Set("s1", "T1")
+	meter.perTurn("s1", codexUsage{InputTokens: 1000, CachedInputTokens: 400, OutputTokens: 100})
+
+	// Rotation: bind to a different thread → baseline must be forgotten.
+	rebindThread("s1", "T2")
+	if threads.Get("s1") != "T2" {
+		t.Fatalf("thread not rebound: got %q want T2", threads.Get("s1"))
+	}
+	in, out, cr := meter.perTurn("s1", codexUsage{InputTokens: 120, CachedInputTokens: 30, OutputTokens: 12})
+	if in != 90 || out != 12 || cr != 30 { // baseline forgotten → derived split of raw
+		t.Fatalf("after rotation = in:%d out:%d cr:%d, want 90/12/30 (baseline forgotten)", in, out, cr)
+	}
+
+	// Rebind to the SAME thread → baseline preserved, next turn diffs normally.
+	rebindThread("s1", "T2")
+	in, out, cr = meter.perTurn("s1", codexUsage{InputTokens: 200, CachedInputTokens: 50, OutputTokens: 20})
+	if in != 60 || out != 8 || cr != 20 { // derived {150,50,20} - baseline {90,30,12}
+		t.Fatalf("after same-thread rebind = in:%d out:%d cr:%d, want 60/8/20 (baseline preserved)", in, out, cr)
+	}
+}
+
+// turnUsage must not panic when the global meter is nil (a handler/test path that
+// didn't run main()); it falls back to mapping the raw usage.
+func TestTurnUsageNilMeterPassThrough(t *testing.T) {
+	oldMeter := meter
+	meter = nil
+	defer func() { meter = oldMeter }()
+
+	in, out, cr := turnUsage("s1", &codexUsage{InputTokens: 1000, CachedInputTokens: 400, OutputTokens: 100})
+	if in != 600 || out != 100 || cr != 400 { // raw mapUsage: 1000-400 / 100 / 400
+		t.Fatalf("nil-meter turnUsage = in:%d out:%d cr:%d, want 600/100/400 (raw mapUsage)", in, out, cr)
+	}
+}


### PR DESCRIPTION
## 背景

codex 每个 `turn.completed` 上报的 usage 是**整个 thread 的累计值**，而非单轮值。relay 跨请求 resume 同一个 thread（见 `threadMap`），导致长会话的 input/output 单调累加 —— 直接写进 chat 日志会把之前每一轮都重复计费。

生产环境（2026-06）一个 78 轮会话因此把 input 放大了约 40 倍，单轮 input 达到 5.5M，远超任何模型上下文窗口，才暴露此问题。这与 relay-claude 侧已修复的 channel usage 累计问题同源。

## 改动

- **新增 `usageMeter`**（`usage_meter.go`）：以 per-session 高水位 baseline 做差分，把 codex 的 thread 累计值还原成单轮 usage。
- **baseline 持久化**到 session 目录下的 `codex_usage.json`（与 `codex_thread.txt` 同寿命，session cleanup 一起回收）。codex 的累计计数器活在 thread 里、比 relay 进程活得久，不持久化的话 relay 重启后会 diff against 0、把整个 thread 重算一遍。
- **stream / non-stream 两条路径**改用 `turnUsage()` 走差分。
- **`rebindThread()`**：codex 轮换到不同 thread 时先 `Forget` 旧 baseline（新 thread 计数器从 0 重启）；thread 失效（resume 报错）时同步 `meter.Forget()`。
- 原子写（tmp+rename）+ corrupt baseline 大声报警，避免静默把累计值当单轮重复计费。
- 版本 `1.1.5` → `1.1.6`。

## 已知取舍

新版**首次部署**到一个已在运行的 thread 上时还没有 baseline 文件，会 diff against 0、把该 thread 已累积的量当作一轮计一次（每个活跃 session 一次性膨胀，量级 = 部署时的积压）。无法在没有前一轮的情况下恢复真实基准，故选择接受而非拦截，并由 `TestUsageMeterEmptyBaselineInflatesOnce` 固定该行为。

## 测试

- `go build ./cmd/relay-codex/` ✅
- `go test ./cmd/relay-codex/` ✅（新增 `usage_meter_test.go`，覆盖差分、乱序完成、空 baseline 一次性膨胀、`Forget`、磁盘持久化往返等场景）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
