### PR TITLE
fix: token 用量统计全链路修复——V1/V2 中断记账、V3 transcript 计量、codex 死线程与异常路径（合并 #27 codex 差分）

### DIFF
--- a/cmd/relay-claude/channel.go
+++ b/cmd/relay-claude/channel.go
@@ -501,10 +501,15 @@ type spawnParams struct {
 // and retries with the opposite flag if claude rejects the first choice.
 // Spawning is single-flighted per session (A8): concurrent requests that miss
 // the registry wait for the in-progress spawn and re-check, instead of racing
-// a second process onto the same session.
-func (m *chanManager) acquire(sessionID string, p spawnParams) (*chanWorker, error) {
+// a second process onto the same session. ctx bounds the wait: a disconnected
+// client must not queue up behind a failing spawn chain, become the next
+// spawner and burn a turn nobody is listening to.
+func (m *chanManager) acquire(ctx context.Context, sessionID string, p spawnParams) (*chanWorker, error) {
 	var spawnCh chan struct{}
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("acquire session %s: %w", sessionID, err)
+		}
 		m.mu.Lock()
 		if w, ok := m.workers[sessionID]; ok && !w.Dead() {
 			w.markUsed()
@@ -524,7 +529,11 @@ func (m *chanManager) acquire(sessionID string, p spawnParams) (*chanWorker, err
 			// for it and re-check (it may have promoted a live worker, or
 			// failed — in which case this request becomes the next spawner).
 			m.mu.Unlock()
-			<-ch
+			select {
+			case <-ch:
+			case <-ctx.Done():
+				return nil, fmt.Errorf("acquire session %s: %w", sessionID, ctx.Err())
+			}
 			continue
 		}
 		spawnCh = make(chan struct{})

--- a/cmd/relay-claude/channel.go
+++ b/cmd/relay-claude/channel.go
@@ -396,6 +396,12 @@ type chanManager struct {
 	mu       sync.Mutex
 	workers  map[string]*chanWorker
 	inflight map[*chanWorker]struct{}
+	// spawning single-flights acquire() per session_id: the first request
+	// registers a channel here and spawns; concurrent requests for the same
+	// session wait on it and re-check instead of double-spawning (two persistent
+	// processes writing the same session jsonl). Closed + removed when the
+	// spawn attempt finishes, success or not.
+	spawning map[string]chan struct{}
 }
 
 func newChanManager(cfg chanManagerConfig) *chanManager {
@@ -403,6 +409,7 @@ func newChanManager(cfg chanManagerConfig) *chanManager {
 		cfg:      cfg,
 		workers:  make(map[string]*chanWorker),
 		inflight: make(map[*chanWorker]struct{}),
+		spawning: make(map[string]chan struct{}),
 	}
 }
 
@@ -492,36 +499,61 @@ type spawnParams struct {
 // acquire returns a live worker for sessionID, spawning one if necessary. On a
 // fresh spawn it picks --session-id vs --resume from on-disk session presence,
 // and retries with the opposite flag if claude rejects the first choice.
+// Spawning is single-flighted per session (A8): concurrent requests that miss
+// the registry wait for the in-progress spawn and re-check, instead of racing
+// a second process onto the same session.
 func (m *chanManager) acquire(sessionID string, p spawnParams) (*chanWorker, error) {
-	m.mu.Lock()
-	if w, ok := m.workers[sessionID]; ok && !w.Dead() {
-		w.markUsed()
-		// Warn (but honor spawn-time binding) if the model/system changed.
-		if p.model != "" && w.boundModel != "" && p.model != w.boundModel {
-			log.Printf("[channel] WARN session=%s model changed %q->%q; persistent process keeps spawn-time model", sessionID, w.boundModel, p.model)
+	var spawnCh chan struct{}
+	for {
+		m.mu.Lock()
+		if w, ok := m.workers[sessionID]; ok && !w.Dead() {
+			w.markUsed()
+			// Warn (but honor spawn-time binding) if the model/system changed.
+			if p.model != "" && w.boundModel != "" && p.model != w.boundModel {
+				log.Printf("[channel] WARN session=%s model changed %q->%q; persistent process keeps spawn-time model", sessionID, w.boundModel, p.model)
+			}
+			if p.systemPrompt != w.boundSystemPrompt {
+				log.Printf("[channel] WARN session=%s system_prompt changed since spawn; ignored (bound at spawn)", sessionID)
+			}
+			m.mu.Unlock()
+			return w, nil
 		}
-		if p.systemPrompt != w.boundSystemPrompt {
-			log.Printf("[channel] WARN session=%s system_prompt changed since spawn; ignored (bound at spawn)", sessionID)
+		delete(m.workers, sessionID)
+		if ch, ok := m.spawning[sessionID]; ok {
+			// Another request is already spawning this session's worker: wait
+			// for it and re-check (it may have promoted a live worker, or
+			// failed — in which case this request becomes the next spawner).
+			m.mu.Unlock()
+			<-ch
+			continue
 		}
-		m.mu.Unlock()
-		return w, nil
-	}
-	delete(m.workers, sessionID)
-	if m.cfg.MaxChannels > 0 {
-		alive := 0
-		for _, w := range m.workers {
-			if !w.Dead() {
-				alive++
+		spawnCh = make(chan struct{})
+		m.spawning[sessionID] = spawnCh
+		if m.cfg.MaxChannels > 0 {
+			alive := 0
+			for _, w := range m.workers {
+				if !w.Dead() {
+					alive++
+				}
+			}
+			if alive >= m.cfg.MaxChannels {
+				m.evictOldestLocked()
 			}
 		}
-		if alive >= m.cfg.MaxChannels {
-			m.evictOldestLocked()
-		}
+		m.mu.Unlock()
+		break
 	}
-	m.mu.Unlock()
 
 	w, err := m.spawnWithRetry(sessionID, p)
+
+	// Release the single-flight (success or failure) and promote in the SAME
+	// critical section, so a waiter's re-check either sees the live worker or
+	// finds spawning empty and takes over.
+	m.mu.Lock()
+	delete(m.spawning, sessionID)
+	close(spawnCh)
 	if err != nil {
+		m.mu.Unlock()
 		return nil, err
 	}
 
@@ -529,8 +561,15 @@ func (m *chanManager) acquire(sessionID string, p spawnParams) (*chanWorker, err
 	// the spawn ran outside m.mu, so its onDie could have fired-and-found-nothing
 	// before this insert. A dead worker here is returned unregistered; beginTurn
 	// will fail and the caller re-acquires.
-	m.mu.Lock()
 	delete(m.inflight, w)
+	if existing, ok := m.workers[sessionID]; ok && !existing.Dead() && existing != w {
+		// 理论上单飞后到不了这里；防御：已有活 worker 就杀掉新 spawn 的，用旧的，
+		// 保证同一 session 永远只有一个持久进程写它的 jsonl。
+		m.mu.Unlock()
+		log.Printf("[channel] WARN session=%s: live worker appeared during spawn; killing the duplicate", sessionID)
+		w.kill()
+		return existing, nil
+	}
 	if !w.Dead() {
 		m.workers[sessionID] = w
 	}

--- a/cmd/relay-claude/channel_handler.go
+++ b/cmd/relay-claude/channel_handler.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -178,6 +179,23 @@ func handleChannelEphemeralStreamResponse(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// recordEphemeralResult 解析一行残余输出：是 result 就给这轮 ephemeral 记账
+	// （identityMeter 场景：bare/modelUsage 都是本轮值，perModelCounts 直接按实际
+	// 消费模型归属）。返回是否记到（A9）。
+	recordEphemeralResult := func(line string) bool {
+		var event claudeEvent
+		if json.Unmarshal([]byte(line), &event) != nil || event.Type != "result" {
+			return false
+		}
+		pm := perModelCounts(&event, model)
+		if pm == nil {
+			return false
+		}
+		stats.RecordTurn(model, pm)
+		log.Printf("[channel] ephemeral interrupted-turn usage recorded session=%s model=%s per_model=%+v", sid, model, pm)
+		return true
+	}
+
 	// The throwaway process is always killed when this turn ends (completion,
 	// stop, or AskUserQuestion). kill() abandons the active turn (unblocking the
 	// stdout reader), and the background drain lets all worker goroutines exit.
@@ -192,10 +210,15 @@ func handleChannelEphemeralStreamResponse(w http.ResponseWriter, r *http.Request
 		go func() {
 			for {
 				select {
-				case _, ok := <-lines:
+				case ln, ok := <-lines:
 					if !ok {
 						return
 					}
+					// 机会主义收割（A9 minimal）：kill 已发出，SIGKILL 后 claude
+					// 不会再补 result；但进程死前已缓冲进管道的 result 能捞到就
+					// 捞（正常完成路径的 result 已被前台 feed 消费并记账，不会
+					// 走到这里，故无重复计数）。
+					recordEphemeralResult(ln)
 				case <-worker.deadCh:
 					return // process reaped; lines may never close
 				}
@@ -203,6 +226,49 @@ func handleChannelEphemeralStreamResponse(w http.ResponseWriter, r *http.Request
 		}()
 	}
 	defer finish()
+
+	// finishWithHarvest 用于 AskUserQuestion 分支（A9 full）：该轮被我们主动
+	// 截断，result 还没出来。先 stdin interrupt（claude 中止当前轮并 emit 带真实
+	// usage 的 result）→ 限时 10s 收割记账 → 再 kill 兜底 + 排空。
+	finishWithHarvest := func() {
+		if finished {
+			return
+		}
+		finished = true
+		channelMgr.untrackInflight(worker)
+		_ = worker.interrupt()
+		go func() {
+			deadline := time.After(10 * time.Second)
+		harvest:
+			for {
+				select {
+				case ln, ok := <-lines:
+					if !ok {
+						break harvest
+					}
+					if recordEphemeralResult(ln) {
+						break harvest
+					}
+				case <-worker.deadCh:
+					break harvest
+				case <-deadline:
+					log.Printf("[channel] ephemeral usage harvest timed out (10s) session=%s", sid)
+					break harvest
+				}
+			}
+			worker.kill()
+			for {
+				select {
+				case _, ok := <-lines:
+					if !ok {
+						return
+					}
+				case <-worker.deadCh:
+					return
+				}
+			}
+		}()
+	}
 
 	log.Printf("[channel] ephemeral turn start session=%s model=%s chat=%s", sid, model, chatID)
 
@@ -224,17 +290,19 @@ func handleChannelEphemeralStreamResponse(w http.ResponseWriter, r *http.Request
 	heartbeat := time.NewTicker(30 * time.Second)
 	defer heartbeat.Stop()
 
-	t := newSSETranslator(chatID, created, model, "", identityMeter{}) // no session → log no-ops
+	t := newSSETranslator(chatID, created, model, "", identityMeter{}, "") // no session → log no-ops
 	for {
 		select {
 		case <-r.Context().Done():
-			// Upstream disconnected = stop. Ephemeral run: just kill it.
+			// Upstream disconnected = stop. Ephemeral run: just kill it (the
+			// deferred finish's drain still harvests an already-buffered result).
 			log.Printf("[channel] ephemeral stop session=%s (kill)", sid)
 			return
 		case <-worker.deadCh:
 			// Process died mid-turn; `lines` may never close. Finalize and exit
 			// rather than block forever (finish kills + drains).
 			t.flushAggLog()
+			t.EmitFinishIfNoResult(w, flusher) // died without result → synthetic finish (A2)
 			fmt.Fprintf(w, "data: [DONE]\n\n")
 			flusher.Flush()
 			log.Printf("[channel] ephemeral turn end session=%s (process died)", sid)
@@ -245,6 +313,7 @@ func handleChannelEphemeralStreamResponse(w http.ResponseWriter, r *http.Request
 		case line, lok := <-lines:
 			if !lok {
 				t.flushAggLog()
+				t.EmitFinishIfNoResult(w, flusher) // closed without result → synthetic finish (A2)
 				fmt.Fprintf(w, "data: [DONE]\n\n")
 				flusher.Flush()
 				log.Printf("[channel] ephemeral turn end session=%s (completed)", sid)
@@ -254,8 +323,10 @@ func handleChannelEphemeralStreamResponse(w http.ResponseWriter, r *http.Request
 				continue
 			}
 			if t.feed(w, flusher, line, includeUsage) == outcomeAskUserDone {
-				// No session to continue on; the card was emitted, kill the run.
+				// No session to continue on; the card was emitted. Interrupt →
+				// harvest the aborted turn's usage → kill (A9).
 				log.Printf("[channel] ephemeral turn end session=%s (ask_user)", sid)
+				finishWithHarvest()
 				return
 			}
 		}
@@ -321,6 +392,14 @@ func handleChannelStreamResponse(w http.ResponseWriter, r *http.Request, req *op
 	log.Printf("[channel] turn start session=%s claude_sid=%s flag=%s model=%s chat=%s",
 		sessionID, worker.SessionID(), worker.usedFlag, model, chatID)
 
+	// Stats attribution follows the worker's spawn-time model, not the request
+	// model: after a hot model switch the persistent process keeps consuming
+	// under the old model until respawn (A5).
+	meterModel := worker.boundModel
+	if meterModel == "" {
+		meterModel = model
+	}
+
 	// Exactly one of these takes ownership of releasing the worker (endTurn):
 	// the foreground path on normal completion, or a background drainer when we
 	// interrupt (stop / AskUserQuestion). turnReleased guards against both.
@@ -351,7 +430,9 @@ func handleChannelStreamResponse(w http.ResponseWriter, r *http.Request, req *op
 						worker.endTurn()
 						return
 					}
-					advanceMeterFromLine(worker.meter, ln)
+					// 中断轮记账（A7）：解析残余行中的 result，推进 meter 基线的
+					// 同时把这轮的差分 usage 记入 stats（中断轮前台没有任何记账）。
+					recordInterruptedTurnUsage(worker.meter, ln, meterModel)
 				case <-worker.deadCh:
 					// Process died; lines may never close. Stop waiting so the
 					// worker is released rather than leaking this goroutine.
@@ -387,7 +468,7 @@ func handleChannelStreamResponse(w http.ResponseWriter, r *http.Request, req *op
 	heartbeat := time.NewTicker(30 * time.Second)
 	defer heartbeat.Stop()
 
-	t := newSSETranslator(chatID, created, model, sessionID, worker.meter)
+	t := newSSETranslator(chatID, created, model, sessionID, worker.meter, worker.boundModel)
 	ctxCh := r.Context().Done()
 
 	for {
@@ -401,6 +482,7 @@ func handleChannelStreamResponse(w http.ResponseWriter, r *http.Request, req *op
 			// Process died mid-turn; `lines` may never close. Finalize and let
 			// the deferred endTurn release the worker.
 			t.flushAggLog()
+			t.EmitFinishIfNoResult(w, flusher) // died without result → synthetic finish (A2)
 			sessionStore.LogDone(sessionID, t.StreamUsage())
 			fmt.Fprintf(w, "data: [DONE]\n\n")
 			flusher.Flush()
@@ -411,8 +493,11 @@ func handleChannelStreamResponse(w http.ResponseWriter, r *http.Request, req *op
 			flusher.Flush()
 		case line, lok := <-lines:
 			if !lok {
-				// Turn's result closed the channel: normal completion.
+				// Turn's result closed the channel: normal completion. (If the
+				// channel closed WITHOUT a result — e.g. drainStdout scanner
+				// error — the translator still owes a terminal chunk.)
 				t.flushAggLog()
+				t.EmitFinishIfNoResult(w, flusher)
 				sessionStore.LogDone(sessionID, t.StreamUsage())
 				fmt.Fprintf(w, "data: [DONE]\n\n")
 				flusher.Flush()

--- a/cmd/relay-claude/channel_handler.go
+++ b/cmd/relay-claude/channel_handler.go
@@ -199,14 +199,33 @@ func handleChannelEphemeralStreamResponse(w http.ResponseWriter, r *http.Request
 	// The throwaway process is always killed when this turn ends (completion,
 	// stop, or AskUserQuestion). kill() abandons the active turn (unblocking the
 	// stdout reader), and the background drain lets all worker goroutines exit.
+	// drainWithGrace 在 deadCh 已触发后继续限时接收 lines：deadCh 关闭后它恒可
+	// 读，与仍有缓冲的 lines 双就绪时 select 是伪随机选择——不加宽限期会有约一半
+	// 概率把已缓冲的 result 连同 usage 一起丢掉（进程死亡与 result 送达几乎同时
+	// 是 interrupt 的常规时序，不是边角）。
+	drainWithGrace := func(fn func(string) bool) {
+		grace := time.After(500 * time.Millisecond)
+		for {
+			select {
+			case ln, ok := <-lines:
+				if !ok {
+					return
+				}
+				fn(ln)
+			case <-grace:
+				return
+			}
+		}
+	}
+
 	finished := false
 	finish := func() {
 		if finished {
 			return
 		}
 		finished = true
-		channelMgr.untrackInflight(worker)
 		worker.kill()
+		channelMgr.untrackInflight(worker)
 		go func() {
 			for {
 				select {
@@ -220,7 +239,8 @@ func handleChannelEphemeralStreamResponse(w http.ResponseWriter, r *http.Request
 					// 走到这里，故无重复计数）。
 					recordEphemeralResult(ln)
 				case <-worker.deadCh:
-					return // process reaped; lines may never close
+					drainWithGrace(recordEphemeralResult)
+					return
 				}
 			}
 		}()
@@ -235,7 +255,6 @@ func handleChannelEphemeralStreamResponse(w http.ResponseWriter, r *http.Request
 			return
 		}
 		finished = true
-		channelMgr.untrackInflight(worker)
 		_ = worker.interrupt()
 		go func() {
 			deadline := time.After(10 * time.Second)
@@ -250,13 +269,17 @@ func handleChannelEphemeralStreamResponse(w http.ResponseWriter, r *http.Request
 						break harvest
 					}
 				case <-worker.deadCh:
+					drainWithGrace(recordEphemeralResult) // 缓冲里可能还躺着 result
 					break harvest
 				case <-deadline:
 					log.Printf("[channel] ephemeral usage harvest timed out (10s) session=%s", sid)
 					break harvest
 				}
 			}
+			// kill 之后才 untrack：收割窗口（最长 10s）内 worker 必须留在
+			// inflight 里，否则 SIGTERM 时 Stop() 找不到它，claude 变孤儿进程。
 			worker.kill()
+			channelMgr.untrackInflight(worker)
 			for {
 				select {
 				case _, ok := <-lines:
@@ -294,9 +317,11 @@ func handleChannelEphemeralStreamResponse(w http.ResponseWriter, r *http.Request
 	for {
 		select {
 		case <-r.Context().Done():
-			// Upstream disconnected = stop. Ephemeral run: just kill it (the
-			// deferred finish's drain still harvests an already-buffered result).
-			log.Printf("[channel] ephemeral stop session=%s (kill)", sid)
+			// Upstream disconnected = stop. 与 V1/持久 channel 口径一致：先
+			// interrupt 让 claude 吐带真实 usage 的 result 并收割记账，再 kill
+			// 兜底（直接 SIGKILL 的话被停轮的消耗永久漏计）。
+			log.Printf("[channel] ephemeral stop session=%s (interrupt+harvest)", sid)
+			finishWithHarvest()
 			return
 		case <-worker.deadCh:
 			// Process died mid-turn; `lines` may never close. Finalize and exit
@@ -369,7 +394,7 @@ func handleChannelStreamResponse(w http.ResponseWriter, r *http.Request, req *op
 		model:        model,
 	}
 
-	worker, err := channelMgr.acquire(sessionID, p)
+	worker, err := channelMgr.acquire(r.Context(), sessionID, p)
 	if err != nil {
 		log.Printf("[channel] acquire failed session=%s: %v", sessionID, err)
 		openai.WriteError(w, http.StatusInternalServerError, "server_error", err.Error())
@@ -381,7 +406,7 @@ func handleChannelStreamResponse(w http.ResponseWriter, r *http.Request, req *op
 		// Worker died between acquire and beginTurn (e.g. reaped). One retry
 		// with a fresh acquire (which will spawn/resume).
 		log.Printf("[channel] beginTurn failed session=%s: %v; retrying acquire", sessionID, err)
-		if worker, err = channelMgr.acquire(sessionID, p); err == nil {
+		if worker, err = channelMgr.acquire(r.Context(), sessionID, p); err == nil {
 			lines, err = worker.beginTurn(content)
 		}
 		if err != nil {
@@ -434,8 +459,23 @@ func handleChannelStreamResponse(w http.ResponseWriter, r *http.Request, req *op
 					// 同时把这轮的差分 usage 记入 stats（中断轮前台没有任何记账）。
 					recordInterruptedTurnUsage(worker.meter, ln, meterModel)
 				case <-worker.deadCh:
-					// Process died; lines may never close. Stop waiting so the
-					// worker is released rather than leaking this goroutine.
+					// Process died; lines may never close. 先限时扫掉已缓冲的行
+					// （interrupt 的 result 常与进程退出同刻到达，deadCh 与 lines
+					// 双就绪时 select 伪随机，不扫会有约一半概率丢掉这轮记账），
+					// 再释放 worker，避免泄漏本 goroutine。
+					grace := time.After(500 * time.Millisecond)
+				drain:
+					for {
+						select {
+						case ln, ok := <-lines:
+							if !ok {
+								break drain
+							}
+							recordInterruptedTurnUsage(worker.meter, ln, meterModel)
+						case <-grace:
+							break drain
+						}
+					}
 					timer.Stop()
 					worker.endTurn()
 					return

--- a/cmd/relay-claude/channel_test.go
+++ b/cmd/relay-claude/channel_test.go
@@ -448,7 +448,7 @@ func TestNewUUID(t *testing.T) {
 func TestSSETranslatorTextAndResult(t *testing.T) {
 	sessionStore = sessions.New(t.TempDir())
 	rec := httptest.NewRecorder()
-	tr := newSSETranslator("chatcmpl-x", 1700000000, "haiku", "", identityMeter{}) // empty sessionID → log no-ops
+	tr := newSSETranslator("chatcmpl-x", 1700000000, "haiku", "", identityMeter{}, "") // empty sessionID → log no-ops
 
 	textLine := `{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}}`
 	resultLine := `{"type":"result","subtype":"success","usage":{"input_tokens":10,"output_tokens":5},"total_cost_usd":0.001}`
@@ -477,7 +477,7 @@ func TestSSETranslatorTextAndResult(t *testing.T) {
 func TestSSETranslatorAskUserQuestion(t *testing.T) {
 	sessionStore = sessions.New(t.TempDir())
 	rec := httptest.NewRecorder()
-	tr := newSSETranslator("chatcmpl-y", 1700000000, "haiku", "", identityMeter{})
+	tr := newSSETranslator("chatcmpl-y", 1700000000, "haiku", "", identityMeter{}, "")
 
 	start := `{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tu_1","name":"AskUserQuestion"}}}`
 	delta := `{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"questions\":[]}"}}}`
@@ -500,17 +500,19 @@ func TestSSETranslatorAskUserQuestion(t *testing.T) {
 }
 
 // 同一 cumulativeMeter 跨两轮 feed：第二轮 emit 的是 delta，不是累计。
+// 用 modelUsage shape（进程级累计口径）驱动；bare usage 是 per-turn 值，
+// 不走差分（实证依据见 usage_meter.go 注释）。
 func TestSSETranslatorChannelDiffsCumulativeUsage(t *testing.T) {
 	sessionStore = sessions.New(t.TempDir())
 	meter := &cumulativeMeter{}
 
 	rec1 := httptest.NewRecorder()
-	tr1 := newSSETranslator("c1", 1700000000, "haiku", "", meter)
-	tr1.feed(rec1, rec1, `{"type":"result","usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":1000}}`, true)
+	tr1 := newSSETranslator("c1", 1700000000, "haiku", "", meter, "")
+	tr1.feed(rec1, rec1, `{"type":"result","modelUsage":{"claude-haiku":{"inputTokens":100,"outputTokens":50,"cacheReadInputTokens":1000}}}`, true)
 
 	rec2 := httptest.NewRecorder()
-	tr2 := newSSETranslator("c2", 1700000000, "haiku", "", meter)
-	tr2.feed(rec2, rec2, `{"type":"result","usage":{"input_tokens":106,"output_tokens":90,"cache_read_input_tokens":4500}}`, true)
+	tr2 := newSSETranslator("c2", 1700000000, "haiku", "", meter, "")
+	tr2.feed(rec2, rec2, `{"type":"result","modelUsage":{"claude-haiku":{"inputTokens":106,"outputTokens":90,"cacheReadInputTokens":4500}}}`, true)
 
 	u := tr2.StreamUsage()
 	if u == nil {
@@ -529,10 +531,107 @@ func TestSSETranslatorChannelDiffsCumulativeUsage(t *testing.T) {
 func TestSSETranslatorEmitsUsageFromModelUsage(t *testing.T) {
 	sessionStore = sessions.New(t.TempDir())
 	rec := httptest.NewRecorder()
-	tr := newSSETranslator("c", 1700000000, "haiku", "", identityMeter{})
+	tr := newSSETranslator("c", 1700000000, "haiku", "", identityMeter{}, "")
 	line := `{"type":"result","modelUsage":{"claude-haiku":{"inputTokens":10,"outputTokens":5,"cacheReadInputTokens":20}}}`
 	tr.feed(rec, rec, line, true)
 	if !strings.Contains(rec.Body.String(), `"prompt_tokens"`) {
 		t.Errorf("usage chunk missing when only modelUsage present (gating bug):\n%s", rec.Body.String())
+	}
+}
+
+// A2: 进程无 result 就退出时，流必须补一个 finish chunk；正常轮 no-op。
+func TestEmitFinishIfNoResult(t *testing.T) {
+	sessionStore = sessions.New(t.TempDir())
+
+	// 没见过 result → 合成 finish chunk。
+	rec := httptest.NewRecorder()
+	tr := newSSETranslator("c-nofin", 1700000000, "haiku", "", identityMeter{}, "")
+	tr.feed(rec, rec, `{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}}`, true)
+	tr.EmitFinishIfNoResult(rec, rec)
+	if !strings.Contains(rec.Body.String(), `"finish_reason":"stop"`) {
+		t.Errorf("missing synthetic finish chunk when stream ended without result:\n%s", rec.Body.String())
+	}
+
+	// 正常轮（result 已 emit finish）→ no-op，不能出现第二个 finish chunk。
+	rec2 := httptest.NewRecorder()
+	tr2 := newSSETranslator("c-fin", 1700000000, "haiku", "", identityMeter{}, "")
+	tr2.feed(rec2, rec2, `{"type":"result","usage":{"input_tokens":1,"output_tokens":1}}`, false)
+	before := rec2.Body.Len()
+	tr2.EmitFinishIfNoResult(rec2, rec2)
+	if rec2.Body.Len() != before {
+		t.Errorf("EmitFinishIfNoResult must be a no-op after a result event:\n%s", rec2.Body.String())
+	}
+}
+
+// A5: cumulativeMeter 路径的 stats 归属跟 meterModel（worker 的 spawn-time
+// boundModel），而不是请求 model —— 热切模型后不再错归属。
+func TestSSETranslatorAttributesToMeterModel(t *testing.T) {
+	sessionStore = sessions.New(t.TempDir())
+	const boundModel = "test-meter-model-bound"
+	const reqModel = "test-meter-model-request"
+
+	rowTotal := func(model string) int64 {
+		row, ok := stats.Snapshot().PerModel[model]
+		if !ok {
+			return 0
+		}
+		return row.Total
+	}
+	boundBefore, reqBefore := rowTotal(boundModel), rowTotal(reqModel)
+
+	rec := httptest.NewRecorder()
+	tr := newSSETranslator("c-mm", 1700000000, reqModel, "", &cumulativeMeter{}, boundModel)
+	tr.feed(rec, rec, `{"type":"result","modelUsage":{"claude-x":{"inputTokens":11,"outputTokens":7}}}`, true)
+
+	if got := rowTotal(boundModel) - boundBefore; got != 18 {
+		t.Fatalf("boundModel stats delta = %d, want 18", got)
+	}
+	if got := rowTotal(reqModel) - reqBefore; got != 0 {
+		t.Fatalf("request model must not accrue tokens after hot switch, delta = %d", got)
+	}
+}
+
+// A8: 同一 session 的并发 acquire 单飞——第二个请求等待在飞 spawn 完成后复用其
+// worker，而不是并发再起一个进程写同一份 session jsonl。
+func TestAcquireWaitsForInflightSpawn(t *testing.T) {
+	m := newChanManager(chanManagerConfig{})
+	spawnCh := make(chan struct{})
+	m.spawning["s1"] = spawnCh // 模拟已有请求正在 spawn
+
+	type result struct {
+		w   *chanWorker
+		err error
+	}
+	got := make(chan result, 1)
+	go func() {
+		w, err := m.acquire("s1", spawnParams{})
+		got <- result{w, err}
+	}()
+
+	// 等待方必须挂起在 spawning channel 上，而不是自己再 spawn 一个。
+	select {
+	case <-got:
+		t.Fatal("acquire returned before the in-flight spawn finished")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// spawner 完成：晋升 worker + 释放单飞。
+	w := newWorkerAt("s1", time.Now())
+	m.mu.Lock()
+	m.workers["s1"] = w
+	delete(m.spawning, "s1")
+	m.mu.Unlock()
+	close(spawnCh)
+
+	select {
+	case r := <-got:
+		if r.err != nil {
+			t.Fatalf("acquire after spawn finished: %v", r.err)
+		}
+		if r.w != w {
+			t.Fatal("waiter should reuse the worker promoted by the spawner")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter did not wake after the in-flight spawn finished")
 	}
 }

--- a/cmd/relay-claude/channel_test.go
+++ b/cmd/relay-claude/channel_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http/httptest"
@@ -300,7 +301,7 @@ func TestManagerReusesLiveWorker(t *testing.T) {
 	w := newWorkerAt("s1", time.Now())
 	m.workers["s1"] = w
 
-	got, err := m.acquire("s1", spawnParams{})
+	got, err := m.acquire(context.Background(), "s1", spawnParams{})
 	if err != nil {
 		t.Fatalf("acquire: %v", err)
 	}
@@ -604,7 +605,7 @@ func TestAcquireWaitsForInflightSpawn(t *testing.T) {
 	}
 	got := make(chan result, 1)
 	go func() {
-		w, err := m.acquire("s1", spawnParams{})
+		w, err := m.acquire(context.Background(), "s1", spawnParams{})
 		got <- result{w, err}
 	}()
 

--- a/cmd/relay-claude/channelv3.go
+++ b/cmd/relay-claude/channelv3.go
@@ -84,6 +84,17 @@ type v3Session struct {
 	ptyLog    *os.File // optional raw PTY capture for debugging
 
 	bound string // spawn-bound model (for change warnings)
+
+	// Transcript-based usage metering (see v3usage.go). These are only touched
+	// from the turn-owning handler goroutine (V3 runs at most one turn per
+	// session — inTurn semantics), but a small mutex guards them anyway so a
+	// future concurrent reader can't corrupt the offset/dedup state.
+	usageMu        sync.Mutex
+	claudeSID      string              // claude-side session UUID (--session-id) == transcript basename
+	transcriptPath string              // lazily resolved via glob by harvestV3Usage
+	usageOffset    int64               // next transcript read position
+	prevReqIDs     map[string]struct{} // requestIds already counted (cross-window dedup)
+	usageWarned    bool                // "transcript not found" logged once per session
 }
 
 // v3DebugPTY, when true, dumps each session's raw claude TUI to /tmp/v3pty-<sid>.log.
@@ -281,6 +292,110 @@ func (m *v3Manager) drainInbox(sid string) {
 	}
 }
 
+// v3FindTranscript globs for the interactive claude's transcript. The cwd
+// encoding of the project dir is deliberately NOT reimplemented — the session
+// UUID is globally unique, so ~/.claude/projects/*/<uuid>.jsonl matches at most
+// one file.
+func v3FindTranscript(claudeSID string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || claudeSID == "" {
+		return ""
+	}
+	matches, _ := filepath.Glob(filepath.Join(home, ".claude", "projects", "*", claudeSID+".jsonl"))
+	if len(matches) == 0 {
+		return ""
+	}
+	return matches[0]
+}
+
+// harvestV3Usage harvests this turn's token usage at a turn-end point: it
+// lazily locates the transcript (one glob, then cached), reads the incremental
+// window since the previous harvest, records the turn into /v1/stats, and
+// returns the aggregate UsageInfo for the SSE usage chunk.
+//
+// Failure semantics: any failure (transcript not found, read/parse error) →
+// returns nil so the caller emits NO usage chunk and downstream keeps the
+// NULL = "not metered" meaning — a 0 would read as "free request". The request
+// itself is still counted via stats.RecordTurn(model, nil) so /v1/stats request
+// totals stop being blind to V3.
+//
+// graceRetry (used on the normal final-reply path only): if the transcript is
+// missing or the window has no usage yet, wait 1.5s and retry once — the
+// terminal reply can race claude's transcript flush by a moment.
+func (m *v3Manager) harvestV3Usage(s *v3Session, model string, graceRetry bool) *openai.UsageInfo {
+	s.usageMu.Lock()
+	defer s.usageMu.Unlock()
+
+	if s.transcriptPath == "" {
+		p := v3FindTranscript(s.claudeSID)
+		if p == "" && graceRetry {
+			time.Sleep(1500 * time.Millisecond)
+			p = v3FindTranscript(s.claudeSID)
+		}
+		if p == "" {
+			if !s.usageWarned {
+				s.usageWarned = true
+				log.Printf("[v3] usage: transcript not found for claude_sid=%s session=%s — turn not metered", s.claudeSID, s.sid)
+			}
+			stats.RecordTurn(model, nil)
+			return nil
+		}
+		s.transcriptPath = p
+	}
+
+	read := func() (map[string]openai.TokenCounts, error) {
+		perModel, newOff, ids, err := readV3UsageWindow(s.transcriptPath, s.usageOffset, s.prevReqIDs)
+		if err != nil {
+			return nil, err
+		}
+		s.usageOffset = newOff
+		if s.prevReqIDs == nil {
+			s.prevReqIDs = make(map[string]struct{})
+		}
+		for id := range ids {
+			s.prevReqIDs[id] = struct{}{}
+		}
+		return perModel, nil
+	}
+
+	perModel, err := read()
+	if err != nil {
+		log.Printf("[v3] usage: read transcript failed session=%s path=%s: %v — turn not metered", s.sid, s.transcriptPath, err)
+		if os.IsNotExist(err) {
+			s.transcriptPath = "" // vanished (cleanup?) → re-glob next turn
+		}
+		stats.RecordTurn(model, nil)
+		return nil
+	}
+	if len(perModel) == 0 && graceRetry {
+		// Window empty right at final-reply time: give the transcript writer a
+		// moment (write ordering between the reply tool call and the jsonl flush
+		// is not guaranteed), then read the follow-up increment.
+		time.Sleep(1500 * time.Millisecond)
+		if pm2, err2 := read(); err2 == nil {
+			perModel = pm2
+		}
+	}
+
+	if len(perModel) == 0 {
+		// Still count the request so /v1/stats request totals include V3 turns.
+		stats.RecordTurn(model, nil)
+		return nil
+	}
+
+	stats.RecordTurn(model, perModel)
+	var input, output, cacheRead, cacheCreation int
+	for _, c := range perModel {
+		input += c.Input
+		output += c.Output
+		cacheRead += c.CacheRead
+		cacheCreation += c.CacheCreation
+	}
+	log.Printf("[v3] usage session=%s claude_sid=%s models=%d input=%d output=%d cache_read=%d cache_creation=%d",
+		s.sid, s.claudeSID, len(perModel), input, output, cacheRead, cacheCreation)
+	return openai.BuildUsageInfo(input, output, cacheRead, cacheCreation)
+}
+
 // v3TurnOutcome is what one runAttempt() of handleChannelV3Response resolves to.
 type v3TurnOutcome int
 
@@ -366,9 +481,19 @@ func (m *v3Manager) launch(sid string, p v3SpawnParams) (*v3Session, error) {
 		return nil, fmt.Errorf("write .mcp.json: %w", err)
 	}
 
+	// A fresh claude-side session UUID per launch (interactive claude supports
+	// --session-id as a general flag): the transcript lands at
+	// ~/.claude/projects/<encoded-cwd>/<uuid>.jsonl, which harvestV3Usage tails
+	// for token metering. EVERY launch mints a NEW uuid — including a cold-start
+	// relaunch of the same relay sid — because reusing a uuid whose transcript
+	// file already exists would make claude refuse to start or unexpectedly
+	// resume the old conversation. (Relaunch goes acquire→launch→new v3Session,
+	// so the fresh uuid + zeroed usage offset come for free.)
+	claudeSID := newUUID()
 	args := []string{
 		"--dangerously-load-development-channels", "server:relaybridge",
 		"--dangerously-skip-permissions",
+		"--session-id", claudeSID,
 		"--model", p.model,
 	}
 	if p.systemPrompt != "" {
@@ -403,13 +528,15 @@ func (m *v3Manager) launch(sid string, p v3SpawnParams) (*v3Session, error) {
 	}
 
 	s := &v3Session{
-		sid:     sid,
-		cmd:     cmd,
-		ptmx:    ptmx,
-		mcpFile: mcpFile,
-		deadCh:  make(chan struct{}),
-		ready:   make(chan struct{}),
-		bound:   p.model,
+		sid:        sid,
+		cmd:        cmd,
+		ptmx:       ptmx,
+		mcpFile:    mcpFile,
+		deadCh:     make(chan struct{}),
+		ready:      make(chan struct{}),
+		bound:      p.model,
+		claudeSID:  claudeSID,
+		prevReqIDs: make(map[string]struct{}),
 	}
 	if v3DebugPTY {
 		if f, err := os.Create(filepath.Join(os.TempDir(), "v3pty-"+sid+".log")); err == nil {
@@ -429,8 +556,8 @@ func (m *v3Manager) launch(sid string, p v3SpawnParams) (*v3Session, error) {
 		m.onSessionDie(sid)
 	}()
 
-	log.Printf("[v3] launched interactive claude session=%s model=%s pid=%d workdir=%s",
-		sid, p.model, cmd.Process.Pid, p.workingDir)
+	log.Printf("[v3] launched interactive claude session=%s claude_sid=%s model=%s pid=%d workdir=%s",
+		sid, claudeSID, p.model, cmd.Process.Pid, p.workingDir)
 	return s, nil
 }
 
@@ -787,11 +914,14 @@ func handleChannelV3Response(w http.ResponseWriter, r *http.Request, req *openai
 					}
 					continue
 				}
-				v3EmitClose(w, flusher, chatID, created, model, ev.text, includeUsage)
+				// Terminal reply → harvest this turn's transcript usage (with the
+				// grace retry: the reply tool call can race the jsonl flush).
+				usage := v3Mgr.harvestV3Usage(sess, model, true)
+				v3EmitClose(w, flusher, chatID, created, model, ev.text, includeUsage, usage)
 				if ev.text != "" {
 					sessionStore.LogDelta(req.SessionID, ev.text)
 				}
-				sessionStore.LogDone(req.SessionID, nil)
+				sessionStore.LogDone(req.SessionID, usage)
 				log.Printf("[v3] turn end session=%s req=%s streamed=%v finalLen=%d", sid, reqID, streamed, len(ev.text))
 				return v3OutcomeDone
 			case <-heartbeat.C:
@@ -813,14 +943,19 @@ func handleChannelV3Response(w http.ResponseWriter, r *http.Request, req *openai
 					log.Printf("[v3] session died before any output session=%s req=%s", sid, reqID)
 					return v3OutcomeColdHang
 				}
+				var usage *openai.UsageInfo
 				if streamed {
-					v3EmitClose(w, flusher, chatID, created, model, "", includeUsage)
+					// Session died but content already streamed → close cleanly and
+					// still meter what the dead claude wrote to its transcript (no
+					// grace retry: the writer is gone, nothing more will appear).
+					usage = v3Mgr.harvestV3Usage(sess, model, false)
+					v3EmitClose(w, flusher, chatID, created, model, "", includeUsage, usage)
 				} else {
 					fmt.Fprintf(w, "data: %s\n\n", v3ErrChunk(chatID, created, model, "claude session ended"))
 					fmt.Fprintf(w, "data: [DONE]\n\n")
 					flusher.Flush()
 				}
-				sessionStore.LogDone(req.SessionID, nil)
+				sessionStore.LogDone(req.SessionID, usage)
 				log.Printf("[v3] session=%s died mid-turn req=%s streamed=%v", sid, reqID, streamed)
 				return v3OutcomeDone
 			case <-r.Context().Done():
@@ -831,7 +966,10 @@ func handleChannelV3Response(w http.ResponseWriter, r *http.Request, req *openai
 				// ALWAYS surface a visible marker (even mid-stream): never report a
 				// stalled turn as a clean success.
 				v3EmitContentDelta(w, flusher, chatID, created, model, "\n\n⚠️ 任务长时间无新进展，已停止等待。")
-				v3EmitClose(w, flusher, chatID, created, model, "", includeUsage)
+				// Meter whatever the stuck turn actually burned (no grace retry:
+				// nothing has moved for ReplyTotal already).
+				usage := v3Mgr.harvestV3Usage(sess, model, false)
+				v3EmitClose(w, flusher, chatID, created, model, "", includeUsage, usage)
 				log.Printf("[v3] idle timeout (no activity %s) session=%s req=%s streamed=%v", v3Mgr.cfg.ReplyTotal, sid, reqID, streamed)
 				return v3OutcomeDone
 			}
@@ -850,7 +988,11 @@ func handleChannelV3Response(w http.ResponseWriter, r *http.Request, req *openai
 		case v3OutcomeColdHang:
 			if attempt >= maxColdRetries {
 				v3EmitContentDelta(w, flusher, chatID, created, model, "\n\n⚠️ 会话启动多次无响应，请稍后重发。")
-				v3EmitClose(w, flusher, chatID, created, model, "", includeUsage)
+				// sess here is the CURRENT (post-retry) session object; a frozen
+				// cold start usually has an empty transcript, so this mostly just
+				// records the request into /v1/stats (usage stays nil → NULL).
+				usage := v3Mgr.harvestV3Usage(sess, model, false)
+				v3EmitClose(w, flusher, chatID, created, model, "", includeUsage, usage)
 				log.Printf("[v3] cold-start give up after %d retries session=%s req=%s", attempt, sid, reqID)
 				return
 			}
@@ -910,7 +1052,12 @@ func v3EmitContentDelta(w http.ResponseWriter, flusher http.Flusher, chatID stri
 // reply_chunk, finalText is the last remaining piece (often empty) and the
 // earlier deltas have already gone out; when not streamed, finalText is the
 // whole answer (the legacy single-chunk behavior).
-func v3EmitClose(w http.ResponseWriter, flusher http.Flusher, chatID string, created int64, model, finalText string, includeUsage bool) {
+//
+// usage is the transcript-harvested aggregate (harvestV3Usage). Non-nil (and
+// includeUsage) → a usage chunk goes out between the finish chunk and [DONE];
+// nil → NO usage chunk, so downstream stores NULL ("not metered"), never a
+// fake 0 ("free request").
+func v3EmitClose(w http.ResponseWriter, flusher http.Flusher, chatID string, created int64, model, finalText string, includeUsage bool, usage *openai.UsageInfo) {
 	if finalText != "" {
 		chunk := openai.ChatCompletionResponse{
 			ID: chatID, Object: "chat.completion.chunk", Created: created, Model: model,
@@ -928,9 +1075,15 @@ func v3EmitClose(w http.ResponseWriter, flusher http.Flusher, chatID string, cre
 	data, _ := json.Marshal(fin)
 	fmt.Fprintf(w, "data: %s\n\n", data)
 
-	// V3 has no token source (interactive PTY, no stream-json). Emit NO usage
-	// chunk so downstream stores NULL ("not metered"), not 0 ("free request").
-	_ = includeUsage
+	if includeUsage && usage != nil {
+		uc := openai.ChatCompletionResponse{
+			ID: chatID, Object: "chat.completion.chunk", Created: created, Model: model,
+			Choices: []openai.ChatCompletionChoice{},
+			Usage:   usage,
+		}
+		data, _ := json.Marshal(uc)
+		fmt.Fprintf(w, "data: %s\n\n", data)
+	}
 	fmt.Fprintf(w, "data: [DONE]\n\n")
 	flusher.Flush()
 }

--- a/cmd/relay-claude/channelv3.go
+++ b/cmd/relay-claude/channelv3.go
@@ -275,6 +275,7 @@ func (m *v3Manager) killSession(sid string) {
 	delete(m.inbox, sid)
 	m.mu.Unlock()
 	if s != nil {
+		m.flushV3Orphan(s, "kill-session") // 断连后烧掉的尾巴 token 最后一次入账机会
 		s.kill()
 	}
 }
@@ -394,6 +395,47 @@ func (m *v3Manager) harvestV3Usage(s *v3Session, model string, graceRetry bool) 
 	log.Printf("[v3] usage session=%s claude_sid=%s models=%d input=%d output=%d cache_read=%d cache_creation=%d",
 		s.sid, s.claudeSID, len(perModel), input, output, cacheRead, cacheCreation)
 	return openai.BuildUsageInfo(input, output, cacheRead, cacheCreation)
+}
+
+// flushV3Orphan sweeps any transcript increment that accrued OUTSIDE a metered
+// turn window — tokens claude kept burning after a stop/idle-timeout, or the
+// tail of a torn-down session. They belong to an already-counted turn, so they
+// go into /v1/stats as orphan tokens (no request increment) and are NEVER
+// attached to a later turn's usage chunk (that would inflate the next
+// message's robot_chat_logs row). Quiet no-op when there is nothing to sweep.
+func (m *v3Manager) flushV3Orphan(s *v3Session, where string) {
+	if s == nil {
+		return
+	}
+	s.usageMu.Lock()
+	defer s.usageMu.Unlock()
+	if s.transcriptPath == "" {
+		if s.transcriptPath = v3FindTranscript(s.claudeSID); s.transcriptPath == "" {
+			return
+		}
+	}
+	perModel, newOff, ids, err := readV3UsageWindow(s.transcriptPath, s.usageOffset, s.prevReqIDs)
+	if err != nil {
+		return
+	}
+	s.usageOffset = newOff
+	if s.prevReqIDs == nil {
+		s.prevReqIDs = make(map[string]struct{})
+	}
+	for id := range ids {
+		s.prevReqIDs[id] = struct{}{}
+	}
+	if len(perModel) == 0 {
+		return
+	}
+	stats.RecordOrphanTokens(perModel)
+	var input, output int
+	for _, c := range perModel {
+		input += c.Input
+		output += c.Output
+	}
+	log.Printf("[v3] orphan usage swept (%s) session=%s claude_sid=%s input=%d output=%d — attributed to stats only, not to any turn",
+		where, s.sid, s.claudeSID, input, output)
 }
 
 // v3TurnOutcome is what one runAttempt() of handleChannelV3Response resolves to.
@@ -688,7 +730,10 @@ func (m *v3Manager) evictOldestLocked() {
 	s := m.sessions[oldest]
 	delete(m.sessions, oldest)
 	log.Printf("[v3] capacity evict session=%s", oldest)
-	go s.kill()
+	go func() {
+		m.flushV3Orphan(s, "evict")
+		s.kill()
+	}()
 }
 
 // StartReaper kills sessions idle longer than IdleTTL.
@@ -724,6 +769,7 @@ func (m *v3Manager) reapOnce() {
 	m.mu.Unlock()
 	for _, s := range toKill {
 		log.Printf("[v3] reaping idle session=%s", s.sid)
+		m.flushV3Orphan(s, "reap")
 		s.kill()
 	}
 }
@@ -878,6 +924,10 @@ func handleChannelV3Response(w http.ResponseWriter, r *http.Request, req *openai
 		}
 
 		// Phase 2: send the turn into the live session and stream the reply.
+		// 开窗前先把上一轮 stop/超时后 claude 继续写入的遗留增量单独入账（orphan，
+		// 只进 /v1/stats 总账）——否则这些 token 会整段算进本轮的 usage chunk，
+		// 污染下游 robot_chat_logs 的单条消息用量（B-3）。
+		v3Mgr.flushV3Orphan(sess, "turn-start")
 		log.Printf("[v3] turn start session=%s req=%s model=%s chat=%s", sid, reqID, model, chatID)
 		v3Mgr.enqueue(sid, v3Msg{ReqID: reqID, Content: content})
 
@@ -943,12 +993,12 @@ func handleChannelV3Response(w http.ResponseWriter, r *http.Request, req *openai
 					log.Printf("[v3] session died before any output session=%s req=%s", sid, reqID)
 					return v3OutcomeColdHang
 				}
-				var usage *openai.UsageInfo
+				// Meter what the dead claude wrote to its transcript regardless of
+				// whether content streamed（B-1：只发过 progress 的长工具轮同样烧了
+				// 真金白银的 token，进程死亡不能让它从 /v1/stats 消失）。No grace
+				// retry: the writer is gone, nothing more will appear.
+				usage := v3Mgr.harvestV3Usage(sess, model, false)
 				if streamed {
-					// Session died but content already streamed → close cleanly and
-					// still meter what the dead claude wrote to its transcript (no
-					// grace retry: the writer is gone, nothing more will appear).
-					usage = v3Mgr.harvestV3Usage(sess, model, false)
 					v3EmitClose(w, flusher, chatID, created, model, "", includeUsage, usage)
 				} else {
 					fmt.Fprintf(w, "data: %s\n\n", v3ErrChunk(chatID, created, model, "claude session ended"))
@@ -959,6 +1009,10 @@ func handleChannelV3Response(w http.ResponseWriter, r *http.Request, req *openai
 				log.Printf("[v3] session=%s died mid-turn req=%s streamed=%v", sid, reqID, streamed)
 				return v3OutcomeDone
 			case <-r.Context().Done():
+				// 断连（=stop）也要入账（B-2）：收割到目前为止的增量并计请求数；
+				// 之后 claude 继续烧的部分由 turn-start/teardown 的 orphan sweep
+				// 兜底。无 SSE 可发（客户端已走），usage 只进 /v1/stats。
+				_ = v3Mgr.harvestV3Usage(sess, model, false)
 				log.Printf("[v3] client disconnected session=%s req=%s (session kept alive)", sid, reqID)
 				return v3OutcomeClientGone
 			case <-idle.C:

--- a/cmd/relay-claude/channelv3_test.go
+++ b/cmd/relay-claude/channelv3_test.go
@@ -4,19 +4,53 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"clawrelay-api/pkg/openai"
 )
 
-func TestV3EmitCloseOmitsUsage(t *testing.T) {
+// nil usage → NO usage chunk: downstream must keep storing NULL ("not
+// metered"), never a fake 0 ("free request").
+func TestV3EmitCloseNilUsageOmitsChunk(t *testing.T) {
 	rec := httptest.NewRecorder()
-	v3EmitClose(rec, rec, "c", 1700000000, "haiku", "hello", true) // includeUsage=true
+	v3EmitClose(rec, rec, "c", 1700000000, "haiku", "hello", true, nil) // includeUsage=true
 	body := rec.Body.String()
 	if strings.Contains(body, `"prompt_tokens"`) {
-		t.Errorf("V3 must not emit usage (would log as 0, not NULL):\n%s", body)
+		t.Errorf("nil usage must not emit a usage chunk (would log as 0, not NULL):\n%s", body)
 	}
 	if !strings.Contains(body, `"finish_reason":"stop"`) {
 		t.Errorf("missing finish chunk:\n%s", body)
 	}
 	if !strings.Contains(body, `data: [DONE]`) {
 		t.Errorf("missing [DONE]:\n%s", body)
+	}
+}
+
+// Harvested usage + includeUsage → a usage chunk between finish and [DONE].
+func TestV3EmitCloseEmitsHarvestedUsage(t *testing.T) {
+	rec := httptest.NewRecorder()
+	u := openai.BuildUsageInfo(10, 5, 3, 2) // prompt=10+3+2=15, completion=5
+	v3EmitClose(rec, rec, "c", 1700000000, "haiku", "hello", true, u)
+	body := rec.Body.String()
+	if !strings.Contains(body, `"prompt_tokens":15`) || !strings.Contains(body, `"completion_tokens":5`) {
+		t.Errorf("missing usage chunk fields:\n%s", body)
+	}
+	if !strings.Contains(body, `"cached_tokens":3`) || !strings.Contains(body, `"cache_creation_tokens":2`) {
+		t.Errorf("missing prompt_tokens_details:\n%s", body)
+	}
+	finIdx := strings.Index(body, `"finish_reason":"stop"`)
+	useIdx := strings.Index(body, `"prompt_tokens"`)
+	doneIdx := strings.Index(body, "data: [DONE]")
+	if !(finIdx >= 0 && useIdx > finIdx && doneIdx > useIdx) {
+		t.Errorf("usage chunk must sit between finish chunk and [DONE] (fin=%d use=%d done=%d):\n%s",
+			finIdx, useIdx, doneIdx, body)
+	}
+}
+
+// includeUsage=false suppresses the chunk even when usage was harvested.
+func TestV3EmitCloseRespectsIncludeUsage(t *testing.T) {
+	rec := httptest.NewRecorder()
+	v3EmitClose(rec, rec, "c", 1700000000, "haiku", "hello", false, openai.BuildUsageInfo(1, 1, 0, 0))
+	if body := rec.Body.String(); strings.Contains(body, `"prompt_tokens"`) {
+		t.Errorf("includeUsage=false must not emit usage chunk:\n%s", body)
 	}
 }

--- a/cmd/relay-claude/main.go
+++ b/cmd/relay-claude/main.go
@@ -27,7 +27,9 @@ import (
 var version = "2.0.3"
 
 // buildCommit is stamped at build time via:
-//   go build -ldflags "-X main.buildCommit=$(git rev-parse --short HEAD)"
+//
+//	go build -ldflags "-X main.buildCommit=$(git rev-parse --short HEAD)"
+//
 // so /health can tell exactly which source built a running binary (the
 // 1.1.6-not-in-repo incident made version numbers alone untrustworthy).
 var buildCommit = "unknown"

--- a/cmd/relay-claude/main.go
+++ b/cmd/relay-claude/main.go
@@ -24,7 +24,13 @@ import (
 	"clawrelay-api/pkg/sessions"
 )
 
-var version = "2.0.2"
+var version = "2.0.3"
+
+// buildCommit is stamped at build time via:
+//   go build -ldflags "-X main.buildCommit=$(git rev-parse --short HEAD)"
+// so /health can tell exactly which source built a running binary (the
+// 1.1.6-not-in-repo incident made version numbers alone untrustworthy).
+var buildCommit = "unknown"
 
 var defaultModel = "vllm/claude-sonnet-4-6"
 
@@ -228,6 +234,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 		"status":  "healthy",
 		"backend": "claude",
 		"version": version,
+		"commit":  buildCommit,
 		"mode":    relayMode,
 	})
 }

--- a/cmd/relay-claude/process.go
+++ b/cmd/relay-claude/process.go
@@ -147,9 +147,18 @@ func launchClaude(args []string, prompt, workingDir string, envVars map[string]s
 	go func() {
 		defer close(lines)
 		s := bufio.NewScanner(stdoutPipe)
-		s.Buffer(make([]byte, 1024*1024), 1024*1024)
+		// 8MB cap, same as channel.go's drainStdout: a single stream-json line
+		// (e.g. a result event with large tool output) can exceed 1MB, and
+		// bufio.ErrTooLong would silently truncate the stream mid-turn.
+		s.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
 		for s.Scan() {
 			lines <- s.Text()
+		}
+		if err := s.Err(); err != nil {
+			// bufio.ErrTooLong (line > 8MB) or a read error: the stream ends
+			// early and the caller may never see a result event (see
+			// EmitFinishIfNoResult for the downstream mitigation).
+			log.Printf("Claude stdout scanner error (stream truncated): %v", err)
 		}
 		stderrDone.Wait()
 		if err := cmd.Wait(); err != nil {

--- a/cmd/relay-claude/stream.go
+++ b/cmd/relay-claude/stream.go
@@ -5,12 +5,61 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os/exec"
 	"strings"
 	"time"
 
 	"clawrelay-api/pkg/openai"
 	"clawrelay-api/pkg/proc"
 )
+
+// abortClaudeAndHarvestUsage 中断 V1 进程并在后台限时收割该轮 usage：
+// SIGINT → 最多 10s 内解析残余行中的 result（modelUsage 有真实值）→
+// stats.RecordTurn 记账（+日志）→ KillGroup 兜底 + 排空。
+//
+// 实证依据（claude 2.1.199）：被 SIGINT 后 claude 仍会 emit result 事件
+// （subtype=error_during_execution），bare usage 全 0，但 modelUsage 各条目带
+// 真实 token 和 costUSD，顶层 total_cost_usd 也有值 —— 直接 KillGroup 会把这
+// 一轮的消耗整个丢掉，这正是 V1 中断轮从不记账的根因。
+func abortClaudeAndHarvestUsage(cmd *exec.Cmd, lines <-chan string, model, sessionID string) {
+	proc.InterruptGroup(cmd)
+	go func() {
+		deadline := time.After(10 * time.Second)
+	harvest:
+		for {
+			select {
+			case line, ok := <-lines:
+				if !ok {
+					break harvest // producer closed: process exited without a result
+				}
+				if line == "" {
+					continue
+				}
+				var event claudeEvent
+				if err := json.Unmarshal([]byte(line), &event); err != nil {
+					continue
+				}
+				if event.Type != "result" {
+					continue
+				}
+				if pm := perModelCounts(&event, model); pm != nil {
+					stats.RecordTurn(model, pm)
+					log.Printf("interrupted-turn usage recorded: model=%s session=%s per_model=%+v total_cost=$%.4f",
+						model, sessionID, pm, event.TotalCostUSD)
+				}
+				break harvest
+			case <-deadline:
+				log.Printf("interrupted-turn usage harvest timed out (10s): model=%s session=%s", model, sessionID)
+				break harvest
+			}
+		}
+		// Backstop kill (idempotent if SIGINT already ended it) and drain the
+		// remaining lines so the producer goroutine reaches cmd.Wait().
+		proc.KillGroup(cmd)
+		for range lines { //nolint:revive // intentional drain
+		}
+	}()
+}
 
 // handleStreamResponse streams Claude output without tool-call detection.
 // Used when no tools are defined in the request (fast path). The stream-json →
@@ -35,6 +84,8 @@ func handleStreamResponse(w http.ResponseWriter, r *http.Request, args []string,
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
+		// 非用户中断（本地 ResponseWriter 不支持 flush，属于部署/中间件问题），
+		// 不做 SIGINT 收割：直接杀掉并排空即可。
 		log.Printf("Streaming not supported")
 		if cmd := *cmdPtr; cmd != nil {
 			proc.KillGroup(cmd)
@@ -49,7 +100,7 @@ func handleStreamResponse(w http.ResponseWriter, r *http.Request, args []string,
 	heartbeatTicker := time.NewTicker(30 * time.Second)
 	defer heartbeatTicker.Stop()
 
-	t := newSSETranslator(chatID, created, model, sessionID, identityMeter{})
+	t := newSSETranslator(chatID, created, model, sessionID, identityMeter{}, "")
 
 processLines:
 	for {
@@ -57,10 +108,13 @@ processLines:
 		var ok bool
 		select {
 		case <-r.Context().Done():
+			// disconnect (= upstream stop): SIGINT + harvest the aborted turn's
+			// usage before the backstop kill (A3).
 			if cmd := *cmdPtr; cmd != nil {
-				proc.KillGroup(cmd) // disconnect: kill the still-running group
+				abortClaudeAndHarvestUsage(cmd, lines, model, sessionID)
+			} else {
+				proc.DrainLines(lines)
 			}
-			proc.DrainLines(lines)
 			return
 		case <-heartbeatTicker.C:
 			fmt.Fprintf(w, ": keepalive\n\n")
@@ -77,15 +131,19 @@ processLines:
 
 		if t.feed(w, flusher, line, includeUsage) == outcomeAskUserDone {
 			if cmd := *cmdPtr; cmd != nil && cmd.Process != nil {
-				log.Printf("[ASK_USER_QUESTION] killing Claude process group pid=%d", cmd.Process.Pid)
-				proc.KillGroup(cmd)
+				log.Printf("[ASK_USER_QUESTION] interrupting Claude process group pid=%d (usage harvest, then kill)", cmd.Process.Pid)
+				abortClaudeAndHarvestUsage(cmd, lines, model, sessionID)
+			} else {
+				proc.DrainLines(lines)
 			}
-			proc.DrainLines(lines)
 			return
 		}
 	}
 
 	t.flushAggLog()
+	// Process exited without a result event (crash / scanner truncation): give
+	// the client a terminal finish chunk before [DONE] (A2).
+	t.EmitFinishIfNoResult(w, flusher)
 	sessionStore.LogDone(sessionID, t.StreamUsage())
 
 	fmt.Fprintf(w, "data: [DONE]\n\n")
@@ -113,6 +171,7 @@ func handleBufferedStreamResponse(w http.ResponseWriter, r *http.Request, args [
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
+		// 非用户中断（flush 不可用），不做 SIGINT 收割：直接杀掉并排空。
 		log.Printf("Streaming not supported")
 		if cmd := *cmdPtr; cmd != nil {
 			proc.KillGroup(cmd)
@@ -142,10 +201,13 @@ processLines:
 		var ok bool
 		select {
 		case <-r.Context().Done():
+			// disconnect (= upstream stop): SIGINT + harvest the aborted turn's
+			// usage before the backstop kill (A3).
 			if cmd := *cmdPtr; cmd != nil {
-				proc.KillGroup(cmd) // disconnect: kill the still-running group
+				abortClaudeAndHarvestUsage(cmd, lines, model, sessionID)
+			} else {
+				proc.DrainLines(lines)
 			}
-			proc.DrainLines(lines)
 			return
 		case <-heartbeatTicker.C:
 			fmt.Fprintf(w, ": keepalive\n\n")
@@ -238,13 +300,11 @@ processLines:
 					flusher.Flush()
 
 					if cmd := *cmdPtr; cmd != nil && cmd.Process != nil {
-						log.Printf("[ASK_USER_QUESTION] killing Claude process group pid=%d", cmd.Process.Pid)
-						proc.KillGroup(cmd)
+						log.Printf("[ASK_USER_QUESTION] interrupting Claude process group pid=%d (usage harvest, then kill)", cmd.Process.Pid)
+						abortClaudeAndHarvestUsage(cmd, lines, model, sessionID)
+					} else {
+						proc.DrainLines(lines)
 					}
-					go func() {
-						for range lines {
-						}
-					}()
 					return
 				}
 
@@ -319,12 +379,12 @@ processLines:
 			}
 			if eu := effectiveUsage(&event); eu != nil {
 				finalUsage = openai.BuildUsageInfo(eu.InputTokens, eu.OutputTokens, eu.CacheReadInputTokens, eu.CacheCreationInputTokens)
-				stats.Record(model, eu.InputTokens, eu.OutputTokens,
-					eu.CacheCreationInputTokens, eu.CacheReadInputTokens, event.TotalCostUSD)
-				log.Printf("Token usage: model=%s input=%d output=%d cache_read=%d cache_create=%d cost=$%.4f (subagents_included=%v)",
+				// V1 每请求进程：按实际消费模型归属（A4）；下游 usage chunk 仍用聚合值。
+				stats.RecordTurn(model, perModelCounts(&event, model))
+				log.Printf("Token usage: model=%s input=%d output=%d cache_read=%d cache_create=%d cost=$%.4f (per-model attribution, models=%d)",
 					model, eu.InputTokens, eu.OutputTokens,
 					eu.CacheReadInputTokens, eu.CacheCreationInputTokens, event.TotalCostUSD,
-					len(event.ModelUsage) > 0)
+					len(event.ModelUsage))
 			}
 		}
 	}
@@ -448,8 +508,14 @@ func handleNonStreamResponse(w http.ResponseWriter, r *http.Request, args []stri
 	}
 
 	if rawUsage != nil {
-		stats.Record(model, rawUsage.InputTokens, rawUsage.OutputTokens,
-			rawUsage.CacheCreationInputTokens, rawUsage.CacheReadInputTokens, costUSD)
+		// V1 每请求进程：从收集到的事件里找 result，按实际消费模型归属（A4）。
+		var resultEv *claudeEvent
+		for i := range events {
+			if events[i].Type == "result" {
+				resultEv = &events[i]
+			}
+		}
+		stats.RecordTurn(model, perModelCounts(resultEv, model))
 		log.Printf("Token usage: model=%s input=%d output=%d cache_read=%d cache_create=%d cost=$%.4f",
 			model, rawUsage.InputTokens, rawUsage.OutputTokens,
 			rawUsage.CacheReadInputTokens, rawUsage.CacheCreationInputTokens, costUSD)

--- a/cmd/relay-claude/translate.go
+++ b/cmd/relay-claude/translate.go
@@ -47,9 +47,16 @@ type sseTranslator struct {
 	model     string
 	sessionID string
 	meter     usageMeter
+	// meterModel is the model that stats accounting is attributed to. For a
+	// persistent channel worker this is the worker's spawn-time boundModel: a
+	// hot model switch changes the request `model` immediately, but the running
+	// process keeps consuming under the old model until respawn, so billing to
+	// the request model would misattribute. Empty means "same as model".
+	meterModel string
 
 	streamDeltaSent bool
 	streamUsage     *openai.UsageInfo
+	sawResult       bool // a result event reached feed (finish chunk emitted)
 	seenToolNames   map[string]bool
 
 	askUserIdx  int
@@ -63,9 +70,14 @@ type sseTranslator struct {
 	aggCount int
 }
 
-func newSSETranslator(chatID string, created int64, model, sessionID string, meter usageMeter) *sseTranslator {
+// newSSETranslator: meterModel is the stats-attribution model (see the field
+// comment); pass "" for V1/ephemeral paths, where it defaults to model.
+func newSSETranslator(chatID string, created int64, model, sessionID string, meter usageMeter, meterModel string) *sseTranslator {
 	if meter == nil {
 		meter = identityMeter{}
+	}
+	if meterModel == "" {
+		meterModel = model
 	}
 	return &sseTranslator{
 		chatID:        chatID,
@@ -73,6 +85,7 @@ func newSSETranslator(chatID string, created int64, model, sessionID string, met
 		model:         model,
 		sessionID:     sessionID,
 		meter:         meter,
+		meterModel:    meterModel,
 		seenToolNames: map[string]bool{},
 		askUserIdx:    -1,
 		toolBlocks:    map[int]*toolBlock{},
@@ -81,6 +94,27 @@ func newSSETranslator(chatID string, created int64, model, sessionID string, met
 
 // StreamUsage returns the usage captured from the turn's result event, if any.
 func (t *sseTranslator) StreamUsage() *openai.UsageInfo { return t.streamUsage }
+
+// EmitFinishIfNoResult emits a synthetic finish_reason="stop" chunk when the
+// stream is ending without ever having seen a result event (process crashed
+// mid-turn, stdout truncated by a scanner error, worker died) — otherwise the
+// downstream OpenAI client gets [DONE] with no terminal chunk and may treat
+// the response as aborted. No-op after a normal turn: the result branch of
+// feed already emitted the finish chunk (sawResult=true).
+func (t *sseTranslator) EmitFinishIfNoResult(w http.ResponseWriter, flusher http.Flusher) {
+	if t.sawResult {
+		return
+	}
+	log.Printf("stream ended without result event: chat=%s session=%s model=%s; emitting synthetic finish chunk",
+		t.chatID, t.sessionID, t.model)
+	finishReason := "stop"
+	t.emit(w, flusher, openai.ChatCompletionResponse{
+		ID: t.chatID, Object: "chat.completion.chunk", Created: t.created, Model: t.model,
+		Choices: []openai.ChatCompletionChoice{
+			{Index: 0, Delta: openai.NewChatMessage("", ""), FinishReason: &finishReason},
+		},
+	})
+}
 
 func (t *sseTranslator) flushAggLog() {
 	if t.aggCount == 0 {
@@ -274,21 +308,39 @@ func (t *sseTranslator) feed(w http.ResponseWriter, flusher http.Flusher, line s
 	}
 
 	if event.Type == "result" {
+		t.sawResult = true
 		if eu := effectiveUsage(&event); eu != nil {
-			cur := usageSnapshot{
-				input:          eu.InputTokens,
-				output:         eu.OutputTokens,
-				cacheCreation:  eu.CacheCreationInputTokens,
-				cacheRead:      eu.CacheReadInputTokens,
-				costUSD:        event.TotalCostUSD,
-				fromModelUsage: len(event.ModelUsage) > 0,
+			if _, isIdentity := t.meter.(identityMeter); isIdentity {
+				// V1 / ephemeral (one process per turn): the result figures ARE
+				// the per-turn values. Bill per actual consuming model via
+				// modelUsage (sub-agents may run on a different model); the
+				// downstream usage chunk keeps the aggregated view.
+				stats.RecordTurn(t.model, perModelCounts(&event, t.model))
+				log.Printf("Token usage: model=%s input=%d output=%d cache_read=%d cache_create=%d cost=$%.4f (per-model attribution, models=%d)",
+					t.model, eu.InputTokens, eu.OutputTokens,
+					eu.CacheReadInputTokens, eu.CacheCreationInputTokens, event.TotalCostUSD,
+					len(event.ModelUsage))
+				t.streamUsage = openai.BuildUsageInfo(eu.InputTokens, eu.OutputTokens, eu.CacheReadInputTokens, eu.CacheCreationInputTokens)
+			} else {
+				// Persistent channel process: figures are process-cumulative;
+				// the meter diffs them into this turn's delta. Attribution uses
+				// meterModel (the worker's spawn-time model), not the request
+				// model, so a hot model switch can't misattribute (A5).
+				cur := usageSnapshot{
+					input:          eu.InputTokens,
+					output:         eu.OutputTokens,
+					cacheCreation:  eu.CacheCreationInputTokens,
+					cacheRead:      eu.CacheReadInputTokens,
+					costUSD:        event.TotalCostUSD,
+					fromModelUsage: len(event.ModelUsage) > 0,
+				}
+				d := t.meter.perTurn(cur)
+				stats.Record(t.meterModel, d.input, d.output, d.cacheCreation, d.cacheRead, d.costUSD)
+				log.Printf("Token usage: model=%s input=%d output=%d cache_read=%d cache_create=%d cost=$%.4f raw_input=%d raw_cache_read=%d (subagents=%v)",
+					t.meterModel, d.input, d.output, d.cacheRead, d.cacheCreation, d.costUSD,
+					cur.input, cur.cacheRead, cur.fromModelUsage)
+				t.streamUsage = openai.BuildUsageInfo(d.input, d.output, d.cacheRead, d.cacheCreation)
 			}
-			d := t.meter.perTurn(cur)
-			stats.Record(t.model, d.input, d.output, d.cacheCreation, d.cacheRead, d.costUSD)
-			log.Printf("Token usage: model=%s input=%d output=%d cache_read=%d cache_create=%d cost=$%.4f raw_input=%d raw_cache_read=%d (subagents=%v)",
-				t.model, d.input, d.output, d.cacheRead, d.cacheCreation, d.costUSD,
-				cur.input, cur.cacheRead, cur.fromModelUsage)
-			t.streamUsage = openai.BuildUsageInfo(d.input, d.output, d.cacheRead, d.cacheCreation)
 		}
 
 		finishReason := "stop"

--- a/cmd/relay-claude/types.go
+++ b/cmd/relay-claude/types.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"strings"
+
+	"clawrelay-api/pkg/openai"
 )
 
 // claudeEvent is one parsed line of `claude --output-format stream-json`.
@@ -26,6 +28,10 @@ type claudeModelUsage struct {
 	OutputTokens             int `json:"outputTokens"`
 	CacheCreationInputTokens int `json:"cacheCreationInputTokens"`
 	CacheReadInputTokens     int `json:"cacheReadInputTokens"`
+	// CostUSD is per-model cost. Present even on SIGINT-aborted turns (claude
+	// 2.1.199: result subtype=error_during_execution has bare usage all-zero but
+	// modelUsage entries carry real tokens AND costUSD).
+	CostUSD float64 `json:"costUSD"`
 }
 
 // streamAPIEvent mirrors the inner event of a stream_event wrapper, matching
@@ -73,6 +79,41 @@ type claudeUsage struct {
 	OutputTokens             int `json:"output_tokens"`
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
+}
+
+// perModelCounts 把 result 的 modelUsage 转成 stats.RecordTurn 的输入；
+// modelUsage 为空时回退单条 {fallbackModel: bare usage + totalCost}。
+// 用于 V1（每请求进程）与 ephemeral：这些进程只活一轮，result 里的数字天然是
+// per-turn 值，直接按实际消费的模型归属（子代理/Task 工具可能用别的模型）。
+func perModelCounts(ev *claudeEvent, fallbackModel string) map[string]openai.TokenCounts {
+	if ev == nil {
+		return nil
+	}
+	if len(ev.ModelUsage) > 0 {
+		out := make(map[string]openai.TokenCounts, len(ev.ModelUsage))
+		for model, mu := range ev.ModelUsage {
+			out[model] = openai.TokenCounts{
+				Input:         mu.InputTokens,
+				Output:        mu.OutputTokens,
+				CacheCreation: mu.CacheCreationInputTokens,
+				CacheRead:     mu.CacheReadInputTokens,
+				CostUSD:       mu.CostUSD,
+			}
+		}
+		return out
+	}
+	if ev.Usage == nil {
+		return nil
+	}
+	return map[string]openai.TokenCounts{
+		fallbackModel: {
+			Input:         ev.Usage.InputTokens,
+			Output:        ev.Usage.OutputTokens,
+			CacheCreation: ev.Usage.CacheCreationInputTokens,
+			CacheRead:     ev.Usage.CacheReadInputTokens,
+			CostUSD:       ev.TotalCostUSD,
+		},
+	}
 }
 
 // effectiveUsage returns the token usage to report for a result event. When

--- a/cmd/relay-claude/types.go
+++ b/cmd/relay-claude/types.go
@@ -91,6 +91,7 @@ func perModelCounts(ev *claudeEvent, fallbackModel string) map[string]openai.Tok
 	}
 	if len(ev.ModelUsage) > 0 {
 		out := make(map[string]openai.TokenCounts, len(ev.ModelUsage))
+		var costSum float64
 		for model, mu := range ev.ModelUsage {
 			out[model] = openai.TokenCounts{
 				Input:         mu.InputTokens,
@@ -99,6 +100,14 @@ func perModelCounts(ev *claudeEvent, fallbackModel string) map[string]openai.Tok
 				CacheRead:     mu.CacheReadInputTokens,
 				CostUSD:       mu.CostUSD,
 			}
+			costSum += mu.CostUSD
+		}
+		// 兜底：某些 CLI 版本的 modelUsage 条目不带 costUSD——不能让成本静默
+		// 归零，把顶层 total_cost_usd 归到 fallbackModel 名下。
+		if costSum == 0 && ev.TotalCostUSD > 0 {
+			fc := out[fallbackModel]
+			fc.CostUSD = ev.TotalCostUSD
+			out[fallbackModel] = fc
 		}
 		return out
 	}

--- a/cmd/relay-claude/usage_meter.go
+++ b/cmd/relay-claude/usage_meter.go
@@ -40,9 +40,10 @@ func (identityMeter) perTurn(cur usageSnapshot) usageSnapshot { return cur }
 //   - result 的 bare usage 字段是【per-turn 值】（不是累计）；
 //   - 两种 shape 会在同一进程内交替出现（例如无工具的简短轮只给 bare usage）。
 //
-// 因此 token 基线（modelBase）只跟踪 fromModelUsage=true 的流；bare 轮直接取原
-// 值、不动基线 —— 旧实现把 shape 翻转当 reset、把翻回来的累计值整段当全量，
-// 一轮就能虚报几万 cache token，这是本次重写要杀死的 bug。
+// 因此 token 基线（modelBase）只跟踪 fromModelUsage=true 的流；bare 轮直接取
+// 原值入账，并把该值垫进 modelBase（modelUsage 累计包含 bare 轮，垫高基线才能
+// 让下一次差分自然扣除，否则 bare 轮被双计）—— 旧实现把 shape 翻转当 reset、
+// 把翻回来的累计值整段当全量，一轮就能虚报几万 cache token。
 type cumulativeMeter struct {
 	mu           sync.Mutex
 	lastCost     float64
@@ -73,12 +74,18 @@ func (m *cumulativeMeter) perTurn(cur usageSnapshot) usageSnapshot {
 	m.lastCost = cur.costUSD
 
 	if !cur.fromModelUsage {
-		// bare usage 视为 per-turn 值（基于 2.1.199 实证），直接采用，不动
-		// modelBase。代价：bare 间奏轮的 token 会被下一次 modelUsage 差分重复
-		// 覆盖（modelUsage 累计包含了这轮），量级可忽略；换来 shape 翻转时不再
-		// 把整段累计当全量记账。
+		// bare usage 视为 per-turn 值（基于 2.1.199 实证），直接采用。但
+		// modelUsage 的进程级累计【包含】这一轮的消耗，所以必须把 bare 值加进
+		// modelBase 垫高基线——否则下一次 modelUsage 差分会把 bare 轮整段再记
+		// 一遍（bare 轮同样携带数万级 cache_read，双计不是可忽略量级）。
 		d.input, d.output = cur.input, cur.output
 		d.cacheCreation, d.cacheRead = cur.cacheCreation, cur.cacheRead
+		if m.hasModelBase {
+			m.modelBase.input += cur.input
+			m.modelBase.output += cur.output
+			m.modelBase.cacheCreation += cur.cacheCreation
+			m.modelBase.cacheRead += cur.cacheRead
+		}
 		return d
 	}
 
@@ -118,6 +125,9 @@ func recordInterruptedTurnUsage(meter usageMeter, line, model string) {
 	}
 	eu := effectiveUsage(&event)
 	if eu == nil {
+		// result 无任何 usage：请求数仍要入账，与 V3 的 RecordTurn(model, nil)
+		// 口径一致，否则中断场景 total_requests 系统性偏低。
+		stats.RecordTurn(model, nil)
 		return
 	}
 	d := cm.perTurn(usageSnapshot{
@@ -132,5 +142,8 @@ func recordInterruptedTurnUsage(meter usageMeter, line, model string) {
 		stats.Record(model, d.input, d.output, d.cacheCreation, d.cacheRead, d.costUSD)
 		log.Printf("[channel] interrupted-turn usage recorded: model=%s input=%d output=%d cache_read=%d cache_create=%d cost=$%.4f",
 			model, d.input, d.output, d.cacheRead, d.cacheCreation, d.costUSD)
+	} else {
+		// 零增量中断轮（interrupt 落在任何 API 消耗之前）：只计请求数。
+		stats.RecordTurn(model, nil)
 	}
 }

--- a/cmd/relay-claude/usage_meter.go
+++ b/cmd/relay-claude/usage_meter.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"log"
 	"sync"
 )
 
@@ -29,13 +30,31 @@ type identityMeter struct{}
 
 func (identityMeter) perTurn(cur usageSnapshot) usageSnapshot { return cur }
 
-// cumulativeMeter diffs a process-cumulative usage stream into per-turn deltas.
-// Owned by a persistent chanWorker; its lifetime is the claude process's, so a
-// respawned worker starts from a zero baseline, matching the new process's own
-// zero-based cumulative counter.
+// cumulativeMeter converts a persistent process's result-usage stream into
+// per-turn deltas. Owned by a chanWorker; its lifetime is the claude process's,
+// so a respawned worker (incl. --resume) starts from a zero baseline, matching
+// the new process's own zero-based cumulative counters.
+//
+// 实证口径（claude 2.1.199，写死进设计里）：
+//   - result 的 modelUsage 聚合与顶层 total_cost_usd 是【进程级单调累计】；
+//   - result 的 bare usage 字段是【per-turn 值】（不是累计）；
+//   - 两种 shape 会在同一进程内交替出现（例如无工具的简短轮只给 bare usage）。
+//
+// 因此 token 基线（modelBase）只跟踪 fromModelUsage=true 的流；bare 轮直接取原
+// 值、不动基线 —— 旧实现把 shape 翻转当 reset、把翻回来的累计值整段当全量，
+// 一轮就能虚报几万 cache token，这是本次重写要杀死的 bug。
 type cumulativeMeter struct {
-	mu   sync.Mutex
-	last usageSnapshot
+	mu           sync.Mutex
+	lastCost     float64
+	hasModelBase bool
+	modelBase    usageSnapshot // 仅 fromModelUsage=true 流的基线
+}
+
+func clampNonNeg(v int) int {
+	if v < 0 {
+		return 0
+	}
+	return v
 }
 
 func (m *cumulativeMeter) perTurn(cur usageSnapshot) usageSnapshot {
@@ -45,36 +64,50 @@ func (m *cumulativeMeter) perTurn(cur usageSnapshot) usageSnapshot {
 	var d usageSnapshot
 	d.fromModelUsage = cur.fromModelUsage
 
-	// Cost is monotonic (a turn never refunds), so always diff and clamp at 0.
-	d.costUSD = cur.costUSD - m.last.costUSD
+	// Cost 永远全局差分并 clamp≥0：bare result 的 total_cost_usd 也是进程级
+	// 累计口径（与 modelUsage 同源），shape 无关。
+	d.costUSD = cur.costUSD - m.lastCost
 	if d.costUSD < 0 {
 		d.costUSD = 0
 	}
+	m.lastCost = cur.costUSD
 
-	// Reset detection. A source-shape change (modelUsage <-> bare usage) makes
-	// the cumulative figures non-comparable; an input regression means claude
-	// reset its in-process counter (auto-compact / clear). Either way `cur` is
-	// itself the per-turn figure for this turn.
-	if cur.fromModelUsage != m.last.fromModelUsage || cur.input < m.last.input {
+	if !cur.fromModelUsage {
+		// bare usage 视为 per-turn 值（基于 2.1.199 实证），直接采用，不动
+		// modelBase。代价：bare 间奏轮的 token 会被下一次 modelUsage 差分重复
+		// 覆盖（modelUsage 累计包含了这轮），量级可忽略；换来 shape 翻转时不再
+		// 把整段累计当全量记账。
+		d.input, d.output = cur.input, cur.output
+		d.cacheCreation, d.cacheRead = cur.cacheCreation, cur.cacheRead
+		return d
+	}
+
+	// modelUsage 流：无基线（本进程首个 modelUsage result），或 input 回退
+	// （进程内 reset：auto-compact / clear）→ cur 本身就是本轮全量。
+	if !m.hasModelBase || cur.input < m.modelBase.input {
 		d.input, d.output = cur.input, cur.output
 		d.cacheCreation, d.cacheRead = cur.cacheCreation, cur.cacheRead
 	} else {
-		d.input = cur.input - m.last.input
-		d.output = cur.output - m.last.output
-		d.cacheCreation = cur.cacheCreation - m.last.cacheCreation
-		d.cacheRead = cur.cacheRead - m.last.cacheRead
+		// 逐字段差分且每字段 clamp≥0：个别字段（如 cacheCreation）可能因
+		// compact 单独回退，不能让负数污染全局累加器。
+		d.input = clampNonNeg(cur.input - m.modelBase.input)
+		d.output = clampNonNeg(cur.output - m.modelBase.output)
+		d.cacheCreation = clampNonNeg(cur.cacheCreation - m.modelBase.cacheCreation)
+		d.cacheRead = clampNonNeg(cur.cacheRead - m.modelBase.cacheRead)
 	}
-
-	m.last = cur
+	m.modelBase = cur
+	m.hasModelBase = true
 	return d
 }
 
-// advanceMeterFromLine parses a stream-json line and, if it is a result with
-// usage, advances a cumulativeMeter's baseline (discarding the per-turn delta).
-// Used by the background drainer of an interrupted turn so its cumulative usage
-// is absorbed into the baseline instead of bleeding into the next foreground
-// turn. No-op for non-cumulative meters.
-func advanceMeterFromLine(meter usageMeter, line string) {
+// recordInterruptedTurnUsage parses a stream-json line from an interrupted
+// turn's background drainer and, if it is a result with usage, advances the
+// cumulativeMeter's baseline AND records the turn's delta into stats — an
+// interrupted turn produced no foreground accounting at all, so this is its
+// only chance to be billed (SIGINT/stdin-interrupt 后 claude 仍会 emit result，
+// 见 proc.InterruptGroup 注释). No-op for non-result lines and non-cumulative
+// meters (identityMeter callers harvest via perModelCounts directly).
+func recordInterruptedTurnUsage(meter usageMeter, line, model string) {
 	cm, ok := meter.(*cumulativeMeter)
 	if !ok {
 		return
@@ -87,7 +120,7 @@ func advanceMeterFromLine(meter usageMeter, line string) {
 	if eu == nil {
 		return
 	}
-	cm.perTurn(usageSnapshot{
+	d := cm.perTurn(usageSnapshot{
 		input:          eu.InputTokens,
 		output:         eu.OutputTokens,
 		cacheCreation:  eu.CacheCreationInputTokens,
@@ -95,4 +128,9 @@ func advanceMeterFromLine(meter usageMeter, line string) {
 		costUSD:        event.TotalCostUSD,
 		fromModelUsage: len(event.ModelUsage) > 0,
 	})
+	if d.input > 0 || d.output > 0 || d.cacheCreation > 0 || d.cacheRead > 0 || d.costUSD > 0 {
+		stats.Record(model, d.input, d.output, d.cacheCreation, d.cacheRead, d.costUSD)
+		log.Printf("[channel] interrupted-turn usage recorded: model=%s input=%d output=%d cache_read=%d cache_create=%d cost=$%.4f",
+			model, d.input, d.output, d.cacheRead, d.cacheCreation, d.costUSD)
+	}
 }

--- a/cmd/relay-claude/usage_meter_test.go
+++ b/cmd/relay-claude/usage_meter_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestIdentityMeterPassesThrough(t *testing.T) {
 	cur := usageSnapshot{input: 7, output: 3, cacheRead: 9, cacheCreation: 1, costUSD: 0.5}
@@ -9,61 +12,218 @@ func TestIdentityMeterPassesThrough(t *testing.T) {
 	}
 }
 
-func TestCumulativeMeterFirstTurnEqualsCur(t *testing.T) {
+func TestCumulativeMeterFirstModelUsageTurnEqualsCur(t *testing.T) {
 	m := &cumulativeMeter{}
-	d := m.perTurn(usageSnapshot{input: 100, output: 50, cacheRead: 1000, cacheCreation: 200, costUSD: 0.10})
+	d := m.perTurn(usageSnapshot{input: 100, output: 50, cacheRead: 1000, cacheCreation: 200, costUSD: 0.10, fromModelUsage: true})
 	if d.input != 100 || d.output != 50 || d.cacheRead != 1000 || d.cacheCreation != 200 {
 		t.Fatalf("first-turn delta = %+v, want raw values", d)
+	}
+	if math.Abs(d.costUSD-0.10) > 1e-9 {
+		t.Fatalf("first-turn cost = %f, want 0.10", d.costUSD)
 	}
 }
 
 func TestCumulativeMeterDiffsMonotonicGrowth(t *testing.T) {
 	m := &cumulativeMeter{}
-	m.perTurn(usageSnapshot{input: 100, output: 50, cacheRead: 1000, cacheCreation: 200, costUSD: 0.10})
-	d := m.perTurn(usageSnapshot{input: 106, output: 90, cacheRead: 4500, cacheCreation: 200, costUSD: 0.18})
+	m.perTurn(usageSnapshot{input: 100, output: 50, cacheRead: 1000, cacheCreation: 200, costUSD: 0.10, fromModelUsage: true})
+	d := m.perTurn(usageSnapshot{input: 106, output: 90, cacheRead: 4500, cacheCreation: 200, costUSD: 0.18, fromModelUsage: true})
 	if d.input != 6 || d.output != 40 || d.cacheRead != 3500 || d.cacheCreation != 0 {
 		t.Fatalf("second-turn delta = %+v, want increments {6,40,3500,0}", d)
 	}
-	if d.costUSD < 0.0799 || d.costUSD > 0.0801 {
+	if math.Abs(d.costUSD-0.08) > 1e-9 {
 		t.Fatalf("cost delta = %f, want ~0.08", d.costUSD)
 	}
 }
 
 func TestCumulativeMeterResetsOnInputRegression(t *testing.T) {
+	// 进程内 reset（auto-compact / clear）：modelUsage 累计 input 回退 → cur 即全量。
 	m := &cumulativeMeter{}
-	m.perTurn(usageSnapshot{input: 80000, output: 200000, cacheRead: 47000000})
-	d := m.perTurn(usageSnapshot{input: 1300, output: 10000, cacheRead: 4700000})
+	m.perTurn(usageSnapshot{input: 80000, output: 200000, cacheRead: 47000000, fromModelUsage: true})
+	d := m.perTurn(usageSnapshot{input: 1300, output: 10000, cacheRead: 4700000, fromModelUsage: true})
 	if d.input != 1300 || d.output != 10000 || d.cacheRead != 4700000 {
 		t.Fatalf("post-compact delta = %+v, want the cur snapshot (no negatives)", d)
 	}
 }
 
-func TestCumulativeMeterResetsOnSourceShapeChange(t *testing.T) {
+// 本次修复的核心回归用例：shape 翻转 bare→modelUsage 不再把累计当全量。
+// 实证（claude 2.1.199）：bare usage 是 per-turn 值，modelUsage 是进程累计；
+// 旧实现把 shape 变化当 reset，T3 会整段 {1100,1100,66573,8100} 被记成全量。
+func TestCumulativeMeterShapeFlipDoesNotDoubleCount(t *testing.T) {
 	m := &cumulativeMeter{}
-	m.perTurn(usageSnapshot{input: 100, output: 50, fromModelUsage: false})
-	d := m.perTurn(usageSnapshot{input: 5000, output: 9000, fromModelUsage: true})
-	if d.input != 5000 || d.output != 9000 {
-		t.Fatalf("shape-change delta = %+v, want the cur snapshot", d)
+
+	// T1: modelUsage 累计 {542,516,17157,7563} → 无基线，记全量。
+	d1 := m.perTurn(usageSnapshot{input: 542, output: 516, cacheRead: 17157, cacheCreation: 7563, costUSD: 0.10, fromModelUsage: true})
+	if d1.input != 542 || d1.output != 516 || d1.cacheRead != 17157 || d1.cacheCreation != 7563 {
+		t.Fatalf("T1 delta = %+v, want full modelUsage values", d1)
+	}
+
+	// T2: bare {10,38,0,0}（简短间奏轮）→ per-turn 原值，不动 modelUsage 基线。
+	d2 := m.perTurn(usageSnapshot{input: 10, output: 38, costUSD: 0.12, fromModelUsage: false})
+	if d2.input != 10 || d2.output != 38 || d2.cacheRead != 0 || d2.cacheCreation != 0 {
+		t.Fatalf("T2 delta = %+v, want the bare per-turn values {10,38,0,0}", d2)
+	}
+
+	// T3: modelUsage 累计 {1100,1100,66573,8100} → 只记 T3-T1 差分，
+	// 绝不能把 T3 整段当全量（旧 bug 一轮虚报 ~5 万 cache token）。
+	d3 := m.perTurn(usageSnapshot{input: 1100, output: 1100, cacheRead: 66573, cacheCreation: 8100, costUSD: 0.30, fromModelUsage: true})
+	if d3.input != 558 || d3.output != 584 || d3.cacheRead != 49416 || d3.cacheCreation != 537 {
+		t.Fatalf("T3 delta = %+v, want T3-T1 diff {558,584,49416,537}", d3)
+	}
+
+	// cost 全程全局差分：0.10 → 0.02 → 0.18。
+	if math.Abs(d1.costUSD-0.10) > 1e-9 || math.Abs(d2.costUSD-0.02) > 1e-9 || math.Abs(d3.costUSD-0.18) > 1e-9 {
+		t.Fatalf("cost deltas = {%f,%f,%f}, want {0.10,0.02,0.18}", d1.costUSD, d2.costUSD, d3.costUSD)
 	}
 }
 
-func TestAdvanceMeterFromLineAbsorbsDroppedTurn(t *testing.T) {
+func TestCumulativeMeterClampsPerFieldNegatives(t *testing.T) {
+	// input 未回退（不触发 reset），但个别字段回退 → 逐字段 clamp≥0。
 	m := &cumulativeMeter{}
-	// 一个被中断、未走 feed 的 turn：累计推进到 input=500。
-	advanceMeterFromLine(m, `{"type":"result","usage":{"input_tokens":500,"output_tokens":300,"cache_read_input_tokens":9000}}`)
-	// 下一前台 turn 的累计是 input=506，delta 应只含本轮增量，不含被丢轮的 500。
-	d := m.perTurn(usageSnapshot{input: 506, output: 340, cacheRead: 9500})
+	m.perTurn(usageSnapshot{input: 100, output: 50, cacheRead: 1000, cacheCreation: 200, fromModelUsage: true})
+	d := m.perTurn(usageSnapshot{input: 150, output: 60, cacheRead: 900, cacheCreation: 150, fromModelUsage: true})
+	if d.input != 50 || d.output != 10 || d.cacheRead != 0 || d.cacheCreation != 0 {
+		t.Fatalf("delta = %+v, want per-field clamped {50,10,0,0}", d)
+	}
+}
+
+func TestCumulativeMeterCostClampsNegative(t *testing.T) {
+	m := &cumulativeMeter{}
+	m.perTurn(usageSnapshot{costUSD: 0.50, fromModelUsage: true})
+	d := m.perTurn(usageSnapshot{costUSD: 0.10, fromModelUsage: true})
+	if d.costUSD != 0 {
+		t.Fatalf("regressed cost delta = %f, want clamp to 0", d.costUSD)
+	}
+	// 基线已推进到 0.10：下一轮 0.15 → 差分 0.05。
+	d = m.perTurn(usageSnapshot{costUSD: 0.15, fromModelUsage: true})
+	if math.Abs(d.costUSD-0.05) > 1e-9 {
+		t.Fatalf("post-clamp cost delta = %f, want 0.05", d.costUSD)
+	}
+}
+
+// ---- recordInterruptedTurnUsage (A7) ----
+
+func statsModelRow(model string) (requests, total int64, cost float64) {
+	snap := stats.Snapshot()
+	row, ok := snap.PerModel[model]
+	if !ok {
+		return 0, 0, 0
+	}
+	return row.Requests, row.Total, row.CostUSD
+}
+
+func TestRecordInterruptedTurnUsageAdvancesBaselineAndRecords(t *testing.T) {
+	const model = "test-interrupted-a7"
+	m := &cumulativeMeter{}
+	// 先有一轮前台记账：modelUsage 累计推进到 input=500。
+	m.perTurn(usageSnapshot{input: 500, output: 300, cacheRead: 9000, costUSD: 0.10, fromModelUsage: true})
+
+	_, totalBefore, costBefore := statsModelRow(model)
+	// 被中断的一轮：SIGINT/stdin-interrupt 后残余 result（modelUsage 有真实值）。
+	recordInterruptedTurnUsage(m, `{"type":"result","subtype":"error_during_execution","modelUsage":{"claude-x":{"inputTokens":520,"outputTokens":340,"cacheReadInputTokens":9500}},"total_cost_usd":0.14}`, model)
+	_, totalAfter, costAfter := statsModelRow(model)
+
+	// 差分 {20,40,500} = 560 tokens、$0.04 被记入 stats。
+	if totalAfter-totalBefore != 560 {
+		t.Fatalf("stats total delta = %d, want 560", totalAfter-totalBefore)
+	}
+	if math.Abs((costAfter-costBefore)-0.04) > 1e-9 {
+		t.Fatalf("stats cost delta = %f, want 0.04", costAfter-costBefore)
+	}
+
+	// 基线同步推进：下一前台轮只记本轮增量。
+	d := m.perTurn(usageSnapshot{input: 526, output: 380, cacheRead: 10000, costUSD: 0.15, fromModelUsage: true})
 	if d.input != 6 || d.output != 40 || d.cacheRead != 500 {
-		t.Fatalf("delta after background-drain advance = %+v, want {6,40,500}", d)
+		t.Fatalf("delta after interrupted-turn record = %+v, want {6,40,500}", d)
 	}
 }
 
-func TestAdvanceMeterFromLineIgnoresNonResult(t *testing.T) {
+func TestRecordInterruptedTurnUsageIgnoresNonResult(t *testing.T) {
+	const model = "test-interrupted-nonresult"
 	m := &cumulativeMeter{}
-	advanceMeterFromLine(m, `{"type":"stream_event"}`)
-	advanceMeterFromLine(m, `not json`)
-	d := m.perTurn(usageSnapshot{input: 100, output: 50})
+	reqBefore, totalBefore, _ := statsModelRow(model)
+	recordInterruptedTurnUsage(m, `{"type":"stream_event"}`, model)
+	recordInterruptedTurnUsage(m, `not json`, model)
+	reqAfter, totalAfter, _ := statsModelRow(model)
+	if reqAfter != reqBefore || totalAfter != totalBefore {
+		t.Fatal("non-result lines must not touch stats")
+	}
+	d := m.perTurn(usageSnapshot{input: 100, output: 50, fromModelUsage: true})
 	if d.input != 100 {
 		t.Fatalf("baseline moved on non-result line: delta=%+v", d)
+	}
+}
+
+func TestRecordInterruptedTurnUsageZeroDeltaSkipsStats(t *testing.T) {
+	const model = "test-interrupted-zerodelta"
+	m := &cumulativeMeter{}
+	// 基线推进到与残余 result 相同的累计值 → 差分全 0，不应记账。
+	m.perTurn(usageSnapshot{input: 500, output: 300, costUSD: 0.10, fromModelUsage: true})
+	reqBefore, totalBefore, _ := statsModelRow(model)
+	recordInterruptedTurnUsage(m, `{"type":"result","modelUsage":{"claude-x":{"inputTokens":500,"outputTokens":300}},"total_cost_usd":0.10}`, model)
+	reqAfter, totalAfter, _ := statsModelRow(model)
+	if reqAfter != reqBefore || totalAfter != totalBefore {
+		t.Fatal("all-zero delta must not be recorded into stats")
+	}
+}
+
+func TestRecordInterruptedTurnUsageNoopForIdentityMeter(t *testing.T) {
+	const model = "test-interrupted-identity"
+	reqBefore, totalBefore, _ := statsModelRow(model)
+	recordInterruptedTurnUsage(identityMeter{}, `{"type":"result","usage":{"input_tokens":10,"output_tokens":5}}`, model)
+	reqAfter, totalAfter, _ := statsModelRow(model)
+	if reqAfter != reqBefore || totalAfter != totalBefore {
+		t.Fatal("identityMeter must be a no-op (ephemeral harvests via perModelCounts)")
+	}
+}
+
+// ---- perModelCounts (A4) ----
+
+func TestPerModelCountsPrefersModelUsage(t *testing.T) {
+	ev := &claudeEvent{
+		Type: "result",
+		Usage: &claudeUsage{ // bare 全 0（SIGINT 场景），必须不被采用
+			InputTokens: 0, OutputTokens: 0,
+		},
+		ModelUsage: map[string]claudeModelUsage{
+			"claude-opus-4":  {InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 1000, CacheCreationInputTokens: 20, CostUSD: 0.30},
+			"claude-haiku-4": {InputTokens: 7, OutputTokens: 3, CostUSD: 0.01},
+		},
+		TotalCostUSD: 0.31,
+	}
+	pm := perModelCounts(ev, "requested-model")
+	if len(pm) != 2 {
+		t.Fatalf("perModelCounts entries = %d, want 2", len(pm))
+	}
+	opus := pm["claude-opus-4"]
+	if opus.Input != 100 || opus.Output != 50 || opus.CacheRead != 1000 || opus.CacheCreation != 20 || math.Abs(opus.CostUSD-0.30) > 1e-9 {
+		t.Fatalf("opus counts = %+v", opus)
+	}
+	if _, ok := pm["requested-model"]; ok {
+		t.Fatal("fallback model must not appear when modelUsage is present")
+	}
+}
+
+func TestPerModelCountsFallsBackToBareUsage(t *testing.T) {
+	ev := &claudeEvent{
+		Type:         "result",
+		Usage:        &claudeUsage{InputTokens: 10, OutputTokens: 38, CacheReadInputTokens: 5},
+		TotalCostUSD: 0.02,
+	}
+	pm := perModelCounts(ev, "fallback-model")
+	if len(pm) != 1 {
+		t.Fatalf("perModelCounts entries = %d, want 1", len(pm))
+	}
+	c := pm["fallback-model"]
+	if c.Input != 10 || c.Output != 38 || c.CacheRead != 5 || math.Abs(c.CostUSD-0.02) > 1e-9 {
+		t.Fatalf("fallback counts = %+v", c)
+	}
+}
+
+func TestPerModelCountsNilOnNoUsage(t *testing.T) {
+	if pm := perModelCounts(&claudeEvent{Type: "result"}, "m"); pm != nil {
+		t.Fatalf("no usage should yield nil, got %+v", pm)
+	}
+	if pm := perModelCounts(nil, "m"); pm != nil {
+		t.Fatal("nil event should yield nil")
 	}
 }

--- a/cmd/relay-claude/usage_meter_test.go
+++ b/cmd/relay-claude/usage_meter_test.go
@@ -57,17 +57,19 @@ func TestCumulativeMeterShapeFlipDoesNotDoubleCount(t *testing.T) {
 		t.Fatalf("T1 delta = %+v, want full modelUsage values", d1)
 	}
 
-	// T2: bare {10,38,0,0}（简短间奏轮）→ per-turn 原值，不动 modelUsage 基线。
+	// T2: bare {10,38,0,0}（简短间奏轮）→ per-turn 原值，同时垫高 modelUsage 基线
+	// （modelUsage 累计包含 bare 轮，垫高后下一次差分自然扣除，bare 轮不双计）。
 	d2 := m.perTurn(usageSnapshot{input: 10, output: 38, costUSD: 0.12, fromModelUsage: false})
 	if d2.input != 10 || d2.output != 38 || d2.cacheRead != 0 || d2.cacheCreation != 0 {
 		t.Fatalf("T2 delta = %+v, want the bare per-turn values {10,38,0,0}", d2)
 	}
 
-	// T3: modelUsage 累计 {1100,1100,66573,8100} → 只记 T3-T1 差分，
-	// 绝不能把 T3 整段当全量（旧 bug 一轮虚报 ~5 万 cache token）。
+	// T3: modelUsage 累计 {1100,1100,66573,8100} → 记 T3-(T1+T2) 差分：
+	// 既不能把 T3 整段当全量（旧 bug 一轮虚报 ~5 万 cache token），也不能只减
+	// T1（那样 T2 的 bare 值会被第二次入账）。
 	d3 := m.perTurn(usageSnapshot{input: 1100, output: 1100, cacheRead: 66573, cacheCreation: 8100, costUSD: 0.30, fromModelUsage: true})
-	if d3.input != 558 || d3.output != 584 || d3.cacheRead != 49416 || d3.cacheCreation != 537 {
-		t.Fatalf("T3 delta = %+v, want T3-T1 diff {558,584,49416,537}", d3)
+	if d3.input != 548 || d3.output != 546 || d3.cacheRead != 49416 || d3.cacheCreation != 537 {
+		t.Fatalf("T3 delta = %+v, want T3-(T1+T2) diff {548,546,49416,537}", d3)
 	}
 
 	// cost 全程全局差分：0.10 → 0.02 → 0.18。
@@ -153,16 +155,20 @@ func TestRecordInterruptedTurnUsageIgnoresNonResult(t *testing.T) {
 	}
 }
 
-func TestRecordInterruptedTurnUsageZeroDeltaSkipsStats(t *testing.T) {
+func TestRecordInterruptedTurnUsageZeroDeltaCountsRequestOnly(t *testing.T) {
 	const model = "test-interrupted-zerodelta"
 	m := &cumulativeMeter{}
-	// 基线推进到与残余 result 相同的累计值 → 差分全 0，不应记账。
+	// 基线推进到与残余 result 相同的累计值 → 差分全 0：token 不入账，但该 HTTP
+	// 请求仍要计数（与 V3 的 RecordTurn(model, nil) 口径一致）。
 	m.perTurn(usageSnapshot{input: 500, output: 300, costUSD: 0.10, fromModelUsage: true})
 	reqBefore, totalBefore, _ := statsModelRow(model)
 	recordInterruptedTurnUsage(m, `{"type":"result","modelUsage":{"claude-x":{"inputTokens":500,"outputTokens":300}},"total_cost_usd":0.10}`, model)
 	reqAfter, totalAfter, _ := statsModelRow(model)
-	if reqAfter != reqBefore || totalAfter != totalBefore {
-		t.Fatal("all-zero delta must not be recorded into stats")
+	if reqAfter != reqBefore+1 {
+		t.Fatalf("zero-delta interrupted turn must still count the request: req %d -> %d", reqBefore, reqAfter)
+	}
+	if totalAfter != totalBefore {
+		t.Fatal("all-zero delta must not add tokens into stats")
 	}
 }
 

--- a/cmd/relay-claude/v3usage.go
+++ b/cmd/relay-claude/v3usage.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+
+	"clawrelay-api/pkg/openai"
+)
+
+// V3 usage metering source: the interactive claude (PTY) writes every API
+// round's usage into its transcript at
+// ~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl. Empirically verified
+// facts this file relies on:
+//
+//   - assistant rows are top-level {"type":"assistant","requestId":...,
+//     "isSidechain":...,"sessionId":...} with message.model and
+//     message.usage = {input_tokens, cache_creation_input_tokens,
+//     cache_read_input_tokens, output_tokens, ...}.
+//   - CRITICAL: one assistant message is split into 3-5 jsonl rows (one per
+//     content block) with the usage object repeated VERBATIM and the SAME
+//     requestId — dedup by requestId or the turn is over-counted 3-5x.
+//   - isSidechain=true rows are Task sub-agent calls: real billed API rounds,
+//     counted like any other (the requestId dedup rule is universal).
+//   - the transcript has no per-model cost figures → CostUSD stays 0.
+//
+// The cwd encoding of the transcript directory is NOT reimplemented here; the
+// caller locates the file with a glob (~/.claude/projects/*/<uuid>.jsonl).
+
+// v3TranscriptLine is the minimal shape of one transcript jsonl row needed for
+// metering. Kept local to this file on purpose (types.go stays untouched).
+type v3TranscriptLine struct {
+	Type      string `json:"type"`
+	RequestID string `json:"requestId"`
+	Message   *struct {
+		Model string `json:"model"`
+		Usage *struct {
+			InputTokens              int `json:"input_tokens"`
+			CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+			CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+			OutputTokens             int `json:"output_tokens"`
+		} `json:"usage"`
+	} `json:"message"`
+}
+
+// readV3UsageWindow reads the transcript increment [offset, EOF), dedups
+// assistant rows by requestId (against prevReqIDs AND within this window) and
+// aggregates each surviving row's message.usage per model. It returns the
+// per-model aggregate, the new offset, and the set of requestIds seen in THIS
+// window (the caller merges them into its cumulative set — a message's
+// duplicate rows can straddle a window boundary).
+//
+// Incremental-tail semantics:
+//   - a trailing line without '\n' (a write in flight) is NOT consumed:
+//     newOffset stops right before it, so the next window rereads it complete.
+//   - a file shorter than offset means rotation/truncation → reread from 0.
+//   - rows that are not assistant rows, or have no message.usage, are skipped;
+//     an empty message.model is attributed to "unknown".
+//
+// CostUSD is always 0: the transcript carries no per-model cost.
+func readV3UsageWindow(path string, offset int64, prevReqIDs map[string]struct{}) (perModel map[string]openai.TokenCounts, newOffset int64, reqIDs map[string]struct{}, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, offset, nil, err
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, offset, nil, err
+	}
+	if offset < 0 || fi.Size() < offset {
+		offset = 0 // rotation/truncation: start over
+	}
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return nil, offset, nil, err
+	}
+
+	perModel = make(map[string]openai.TokenCounts)
+	reqIDs = make(map[string]struct{})
+	newOffset = offset
+
+	// Rows can be very large (full content blocks), so no Scanner with its
+	// default buffer cap: ReadString on a bufio.Reader grows as needed.
+	rd := bufio.NewReaderSize(f, 64*1024)
+	for {
+		line, rerr := rd.ReadString('\n')
+		if rerr == io.EOF {
+			// Partial trailing line (no '\n'): a write in flight — leave it for
+			// the next window. If line == "" this is just a clean EOF.
+			break
+		}
+		if rerr != nil {
+			return perModel, newOffset, reqIDs, rerr
+		}
+		newOffset += int64(len(line))
+
+		// Cheap pre-filter before the (expensive) unmarshal. Transcript rows are
+		// compact JSON, so the key:value pair appears without spaces.
+		if !strings.Contains(line, `"type":"assistant"`) {
+			continue
+		}
+		var tl v3TranscriptLine
+		if json.Unmarshal([]byte(line), &tl) != nil {
+			continue
+		}
+		if tl.Type != "assistant" || tl.Message == nil || tl.Message.Usage == nil {
+			continue
+		}
+		if rid := tl.RequestID; rid != "" {
+			if _, seen := prevReqIDs[rid]; seen {
+				continue
+			}
+			if _, seen := reqIDs[rid]; seen {
+				continue
+			}
+			reqIDs[rid] = struct{}{}
+		}
+		model := tl.Message.Model
+		if model == "" {
+			model = "unknown"
+		}
+		u := tl.Message.Usage
+		c := perModel[model]
+		c.Input += u.InputTokens
+		c.Output += u.OutputTokens
+		c.CacheCreation += u.CacheCreationInputTokens
+		c.CacheRead += u.CacheReadInputTokens
+		perModel[model] = c
+	}
+	return perModel, newOffset, reqIDs, nil
+}

--- a/cmd/relay-claude/v3usage_test.go
+++ b/cmd/relay-claude/v3usage_test.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"clawrelay-api/pkg/openai"
+)
+
+// v3AsstLine builds one synthetic transcript assistant row (compact JSON +
+// trailing newline), mirroring the real shape: top-level type/requestId/
+// isSidechain, usage under message.usage. Content blocks of one message repeat
+// this row verbatim with the same requestId.
+func v3AsstLine(reqID, model string, in, cc, cr, out int, sidechain bool) string {
+	return fmt.Sprintf(`{"parentUuid":null,"isSidechain":%v,"sessionId":"s-1","timestamp":"2026-07-05T00:00:00Z","type":"assistant","requestId":%q,"message":{"role":"assistant","model":%q,"usage":{"input_tokens":%d,"cache_creation_input_tokens":%d,"cache_read_input_tokens":%d,"output_tokens":%d,"service_tier":"standard"}}}`+"\n",
+		sidechain, reqID, model, in, cc, cr, out)
+}
+
+func v3WriteFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func v3Append(t *testing.T, path, content string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// One assistant message split over 3 rows (same requestId, usage repeated
+// verbatim) must be counted exactly once — the real-world 3-5x over-count trap.
+func TestV3UsageDedupSameRequestIDWithinWindow(t *testing.T) {
+	row := v3AsstLine("req_A", "claude-opus-4", 100, 20, 30, 7, false)
+	path := v3WriteFile(t, row+row+row)
+
+	perModel, newOff, reqIDs, err := readV3UsageWindow(path, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := perModel["claude-opus-4"]
+	if c.Input != 100 || c.CacheCreation != 20 || c.CacheRead != 30 || c.Output != 7 {
+		t.Errorf("duplicated requestId over-counted: %+v", c)
+	}
+	if c.CostUSD != 0 {
+		t.Errorf("transcript has no cost source; CostUSD must be 0, got %v", c.CostUSD)
+	}
+	if len(reqIDs) != 1 {
+		t.Errorf("want 1 requestId seen, got %d", len(reqIDs))
+	}
+	if want := int64(len(row) * 3); newOff != want {
+		t.Errorf("newOffset=%d want %d", newOff, want)
+	}
+}
+
+// A message's duplicate rows can straddle a window boundary: rows of req_A read
+// in window 1 must suppress req_A rows appearing in window 2 (via prevReqIDs).
+func TestV3UsageCrossWindowDedupViaPrevReqIDs(t *testing.T) {
+	rowA := v3AsstLine("req_A", "m", 50, 0, 0, 5, false)
+	path := v3WriteFile(t, rowA)
+
+	pm1, off1, ids1, err := readV3UsageWindow(path, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pm1["m"].Input != 50 {
+		t.Fatalf("window1: %+v", pm1)
+	}
+
+	// The same message's remaining content-block rows + a genuinely new request
+	// arrive later.
+	v3Append(t, path, rowA+rowA+v3AsstLine("req_B", "m", 7, 0, 0, 3, false))
+
+	pm2, _, _, err := readV3UsageWindow(path, off1, ids1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := pm2["m"]
+	if c.Input != 7 || c.Output != 3 {
+		t.Errorf("cross-window dedup failed (req_A recounted): %+v", c)
+	}
+}
+
+// The offset must make each window an increment: window 2 starting at window
+// 1's newOffset sees only rows appended after window 1.
+func TestV3UsageOffsetIncrementalSemantics(t *testing.T) {
+	path := v3WriteFile(t, v3AsstLine("req_A", "m", 10, 0, 0, 1, false))
+
+	_, off1, _, err := readV3UsageWindow(path, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v3Append(t, path, v3AsstLine("req_B", "m", 20, 0, 0, 2, false))
+
+	pm2, off2, _, err := readV3UsageWindow(path, off1, map[string]struct{}{"req_A": {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c := pm2["m"]; c.Input != 20 || c.Output != 2 {
+		t.Errorf("window2 must only see the appended row: %+v", c)
+	}
+	if fi, _ := os.Stat(path); off2 != fi.Size() {
+		t.Errorf("off2=%d want file size %d", off2, fi.Size())
+	}
+}
+
+// A trailing row without '\n' (a write in flight) must NOT be consumed:
+// newOffset stops before it, and once completed it is read by the next window.
+func TestV3UsagePartialLastLineNotConsumed(t *testing.T) {
+	full := v3AsstLine("req_A", "m", 10, 0, 0, 1, false)
+	partialRow := v3AsstLine("req_B", "m", 99, 0, 0, 9, false)
+	half := partialRow[:len(partialRow)/2] // no trailing newline
+	path := v3WriteFile(t, full+half)
+
+	pm1, off1, _, err := readV3UsageWindow(path, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c := pm1["m"]; c.Input != 10 || c.Output != 1 {
+		t.Errorf("partial row must not be counted: %+v", c)
+	}
+	if want := int64(len(full)); off1 != want {
+		t.Errorf("newOffset must stop before the partial row: got %d want %d", off1, want)
+	}
+
+	// Writer finishes the row → next window picks it up whole.
+	v3Append(t, path, partialRow[len(partialRow)/2:])
+	pm2, _, _, err := readV3UsageWindow(path, off1, map[string]struct{}{"req_A": {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c := pm2["m"]; c.Input != 99 || c.Output != 9 {
+		t.Errorf("completed row not read in next window: %+v", c)
+	}
+}
+
+// isSidechain=true rows are Task sub-agent calls — real billed API rounds,
+// counted under the same requestId dedup rule.
+func TestV3UsageSidechainRowsCounted(t *testing.T) {
+	path := v3WriteFile(t,
+		v3AsstLine("req_A", "m", 10, 0, 0, 1, false)+
+			v3AsstLine("req_S", "m", 40, 0, 0, 4, true))
+
+	pm, _, _, err := readV3UsageWindow(path, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c := pm["m"]; c.Input != 50 || c.Output != 5 {
+		t.Errorf("sidechain row must be counted: %+v", c)
+	}
+}
+
+// Non-assistant rows and assistant rows without message.usage are skipped.
+func TestV3UsageSkipsNonAssistantAndNoUsage(t *testing.T) {
+	content := `{"type":"user","message":{"role":"user","content":"hi"}}` + "\n" +
+		`{"type":"summary","summary":"x"}` + "\n" +
+		`{"type":"assistant","requestId":"req_NU","message":{"role":"assistant","model":"m","content":[]}}` + "\n" + // no usage
+		`{"type":"system","subtype":"info","content":"note about \"type\":\"assistant\" rows"}` + "\n" + // cheap filter matches, unmarshal disqualifies
+		v3AsstLine("req_A", "m", 5, 0, 0, 2, false)
+	path := v3WriteFile(t, content)
+
+	pm, newOff, reqIDs, err := readV3UsageWindow(path, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pm) != 1 {
+		t.Fatalf("only the usage-bearing assistant row must count: %v", pm)
+	}
+	if c := pm["m"]; c.Input != 5 || c.Output != 2 {
+		t.Errorf("aggregate wrong: %+v", c)
+	}
+	if _, ok := reqIDs["req_NU"]; ok {
+		t.Errorf("usage-less row must not claim its requestId")
+	}
+	if want := int64(len(content)); newOff != want {
+		t.Errorf("skipped rows must still advance the offset: got %d want %d", newOff, want)
+	}
+}
+
+// A file shorter than the stored offset means rotation/truncation → reread
+// from 0 instead of erroring or reading garbage.
+func TestV3UsageRotationRereadsFromZero(t *testing.T) {
+	longRow := v3AsstLine("req_A", "m", 1000, 0, 0, 100, false)
+	path := v3WriteFile(t, longRow+longRow) // large file
+	_, bigOff, _, err := readV3UsageWindow(path, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Rotate: file replaced by shorter, fresh content.
+	if err := os.WriteFile(path, []byte(v3AsstLine("req_NEW", "m", 3, 0, 0, 1, false)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pm, newOff, _, err := readV3UsageWindow(path, bigOff, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c := pm["m"]; c.Input != 3 || c.Output != 1 {
+		t.Errorf("rotation must reread from 0: %+v", c)
+	}
+	if fi, _ := os.Stat(path); newOff != fi.Size() {
+		t.Errorf("newOffset after rotation reread: got %d want %d", newOff, fi.Size())
+	}
+}
+
+// Usage lands under the model that actually served the request; an empty
+// message.model falls back to "unknown".
+func TestV3UsageMultiModelAttribution(t *testing.T) {
+	path := v3WriteFile(t,
+		v3AsstLine("req_A", "claude-opus-4", 100, 10, 20, 5, false)+
+			v3AsstLine("req_B", "claude-haiku-4", 30, 0, 0, 3, true)+
+			v3AsstLine("req_C", "", 7, 0, 0, 1, false))
+
+	pm, _, _, err := readV3UsageWindow(path, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]openai.TokenCounts{
+		"claude-opus-4":  {Input: 100, CacheCreation: 10, CacheRead: 20, Output: 5},
+		"claude-haiku-4": {Input: 30, Output: 3},
+		"unknown":        {Input: 7, Output: 1},
+	}
+	for model, w := range want {
+		if got := pm[model]; got != w {
+			t.Errorf("model %s: got %+v want %+v", model, got, w)
+		}
+	}
+	if len(pm) != len(want) {
+		t.Errorf("unexpected models: %v", pm)
+	}
+}
+
+// A missing transcript file surfaces as an error (the harvester turns that
+// into "not metered", never a zero).
+func TestV3UsageMissingFileErrors(t *testing.T) {
+	_, off, _, err := readV3UsageWindow(filepath.Join(t.TempDir(), "nope.jsonl"), 42, nil)
+	if err == nil {
+		t.Fatal("want error for missing file")
+	}
+	if off != 42 {
+		t.Errorf("offset must be preserved on open failure: got %d", off)
+	}
+}

--- a/cmd/relay-codex/codex.go
+++ b/cmd/relay-codex/codex.go
@@ -57,10 +57,10 @@ func cleanEnv(extra map[string]string) []string {
 // session/thread reconciliation. It captures whether this turn is a fresh
 // session or a resume, and whether multipart history needs flattening.
 type codexInput struct {
-	Args      []string  // CLI args after `codex`
-	Stdin     string    // body to pipe on stdin
-	IsResume  bool      // true = `codex exec resume <thread_id>` pattern
-	ImagePath []string  // images to attach via -i (collected from latest user message)
+	Args      []string // CLI args after `codex`
+	Stdin     string   // body to pipe on stdin
+	IsResume  bool     // true = `codex exec resume <thread_id>` pattern
+	ImagePath []string // images to attach via -i (collected from latest user message)
 }
 
 // buildCodexInput converts the high-level OpenAI request into a fully-resolved

--- a/cmd/relay-codex/codex.go
+++ b/cmd/relay-codex/codex.go
@@ -262,10 +262,26 @@ func flattenForFreshSession(messages []openai.ChatMessage, sessionDir string) (p
 	return
 }
 
+// newRebuildFresh builds the retry closure used when resuming a codex thread
+// yields zero output. Verified empirically: `codex exec resume <dead-thread>`
+// exits 1 with EMPTY stdout — the "no rollout found for thread id ..." text
+// goes to stderr only, so no parseable error event ever reaches the handlers.
+// The closure drops the stale session→thread binding and rebuilds the input
+// as a brand-new session with the full message history replayed.
+func newRebuildFresh(threads *threadMap, req *openai.ChatCompletionRequest, model, sessionDir string) func() codexInput {
+	return func() codexInput {
+		threads.Forget(req.SessionID)
+		return buildCodexInput(req, model, "", sessionDir)
+	}
+}
+
 // launchCodex starts a `codex` subprocess and returns line channels. lines
-// carries stdout JSONL events; the channel closes after Wait. envExtra is
-// merged into the inherited environment minus codex bookkeeping vars.
-func launchCodex(input codexInput, workingDir string, envExtra map[string]string) (*exec.Cmd, <-chan string, error) {
+// carries stdout JSONL events; the channel closes after Wait. waitErr blocks
+// until the process has been reaped and returns cmd.Wait()'s error — because
+// close(lines) is deferred past cmd.Wait(), waitErr never blocks once the
+// caller has observed lines closing. envExtra is merged into the inherited
+// environment minus codex bookkeeping vars.
+func launchCodex(input codexInput, workingDir string, envExtra map[string]string) (*exec.Cmd, <-chan string, func() error, error) {
 	cmd := exec.Command("codex", input.Args...)
 	// Own process group so KillGroup can reap the whole tree (node wrapper +
 	// native codex binary) instead of orphaning the native child.
@@ -278,14 +294,14 @@ func launchCodex(input codexInput, workingDir string, envExtra map[string]string
 
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create stdout pipe: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to create stdout pipe: %v", err)
 	}
 	stderrPipe, err := cmd.StderrPipe()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create stderr pipe: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to create stderr pipe: %v", err)
 	}
 	if err := cmd.Start(); err != nil {
-		return nil, nil, fmt.Errorf("failed to start codex: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to start codex: %v", err)
 	}
 
 	var stderrDone sync.WaitGroup
@@ -299,18 +315,34 @@ func launchCodex(input codexInput, workingDir string, envExtra map[string]string
 	}()
 
 	lines := make(chan string, 128)
+	waitDone := make(chan struct{})
+	var waitErrVal error // written once, before close(waitDone)
 	go func() {
-		defer close(lines)
+		defer close(lines) // deferred LAST → lines closes only after cmd.Wait()
 		s := bufio.NewScanner(stdoutPipe)
-		s.Buffer(make([]byte, 1024*1024), 1024*1024)
+		// 8MB max token: codex can emit very large single-line JSONL events
+		// (aggregated command output, big agent messages). The previous 1MB cap
+		// made the scanner abort silently mid-stream on oversized lines.
+		s.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
 		for s.Scan() {
 			lines <- s.Text()
 		}
+		if err := s.Err(); err != nil {
+			log.Printf("WARNING: codex stdout scan aborted: %v (remaining output lost)", err)
+		}
 		stderrDone.Wait()
-		if err := cmd.Wait(); err != nil {
+		err := cmd.Wait()
+		if err != nil {
 			log.Printf("codex command error: %v", err)
 		}
+		waitErrVal = err
+		close(waitDone)
 	}()
 
-	return cmd, lines, nil
+	waitErr := func() error {
+		<-waitDone
+		return waitErrVal
+	}
+
+	return cmd, lines, waitErr, nil
 }

--- a/cmd/relay-codex/codex.go
+++ b/cmd/relay-codex/codex.go
@@ -271,6 +271,12 @@ func flattenForFreshSession(messages []openai.ChatMessage, sessionDir string) (p
 func newRebuildFresh(threads *threadMap, req *openai.ChatCompletionRequest, model, sessionDir string) func() codexInput {
 	return func() codexInput {
 		threads.Forget(req.SessionID)
+		// The replacement thread restarts its cumulative counter from zero;
+		// keeping the old high-water baseline would clamp every following
+		// turn's diff to 0 (under-billing) until the new thread caught up.
+		if meter != nil {
+			meter.Forget(req.SessionID)
+		}
 		return buildCodexInput(req, model, "", sessionDir)
 	}
 }

--- a/cmd/relay-codex/codex_test.go
+++ b/cmd/relay-codex/codex_test.go
@@ -155,6 +155,70 @@ func TestResolveCodexUploadDir(t *testing.T) {
 	}
 }
 
+// TestIsStaleThreadErr locks in the CODEX-1 keyword fix: the verified
+// real-world dead-thread error is "no rollout found for thread id ..." —
+// it contains neither "session" (the only keyword the old code matched) nor
+// any stable error code.
+func TestIsStaleThreadErr(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want bool
+	}{
+		{"no rollout found for thread id 01997e2d-ab12", true},
+		{"ROLLOUT file missing", true}, // case-insensitive
+		{"thread 01997e2d not found", true},
+		{"session expired", true},
+		{"rate limit exceeded, retry later", false},
+		{"stream error: connection reset", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isStaleThreadErr(c.msg); got != c.want {
+			t.Errorf("isStaleThreadErr(%q) = %v, want %v", c.msg, got, c.want)
+		}
+	}
+}
+
+// TestNewRebuildFreshForgetsAndReplaysFullHistory: the retry closure must
+// (1) drop the stale session→thread binding and (2) rebuild the input as a
+// non-resume invocation that replays the FULL message history — a fresh codex
+// session knows nothing, so sending only the latest turn would lose context.
+func TestNewRebuildFreshForgetsAndReplaysFullHistory(t *testing.T) {
+	tm := newThreadMap(t.TempDir())
+	tm.Set("sess-1", "thread-dead")
+
+	req := &openai.ChatCompletionRequest{
+		SessionID: "sess-1",
+		Messages: []openai.ChatMessage{
+			{Role: "system", Content: json.RawMessage(`"rules"`)},
+			{Role: "user", Content: json.RawMessage(`"第一轮提问"`)},
+			{Role: "assistant", Content: json.RawMessage(`"第一轮答复"`)},
+			{Role: "user", Content: json.RawMessage(`"第二轮提问"`)},
+		},
+	}
+
+	rebuild := newRebuildFresh(tm, req, "codex/gpt-5.4", "")
+	in := rebuild()
+
+	if in.IsResume {
+		t.Fatal("rebuilt input must not be a resume")
+	}
+	if strings.Contains(strings.Join(in.Args, " "), "resume") {
+		t.Fatalf("rebuilt args must not contain resume: %v", in.Args)
+	}
+	if got := tm.Get("sess-1"); got != "" {
+		t.Fatalf("stale binding not forgotten: %q", got)
+	}
+	for _, want := range []string{"第一轮提问", "第一轮答复", "第二轮提问"} {
+		if !strings.Contains(in.Stdin, want) {
+			t.Fatalf("fresh rebuild must replay full history, missing %q; got:\n%s", want, in.Stdin)
+		}
+	}
+	if !strings.HasPrefix(in.Stdin, `<system_rules priority="highest">`) {
+		t.Fatalf("rebuilt stdin missing system_rules block; got:\n%s", in.Stdin)
+	}
+}
+
 func jsonEscape(s string) string {
 	b, _ := json.Marshal(s)
 	return strings.Trim(string(b), `"`)

--- a/cmd/relay-codex/codex_test.go
+++ b/cmd/relay-codex/codex_test.go
@@ -170,6 +170,10 @@ func TestIsStaleThreadErr(t *testing.T) {
 		{"session expired", true},
 		{"rate limit exceeded, retry later", false},
 		{"stream error: connection reset", false},
+		// 单凭名词命中不删绑定（C2 收紧）：panic/限流文本含 thread/session 但
+		// 线程仍有效，Forget 会把瞬态故障放大成整会话上下文丢失。
+		{"thread 'tokio-runtime-worker' panicked at src/main.rs", false},
+		{"usage limit reached for this session", false},
 		{"", false},
 	}
 	for _, c := range cases {

--- a/cmd/relay-codex/main.go
+++ b/cmd/relay-codex/main.go
@@ -31,7 +31,13 @@ import (
 	"clawrelay-api/pkg/sessions"
 )
 
-var version = "1.1.5"
+// version 1.1.6 被生产二进制占用但源码从未入库（版本漂移事故），跳到 1.1.7
+// 以保证线上版本号可比较；buildCommit 让 /health 能定位构建源。
+var version = "1.1.7"
+
+// buildCommit is stamped at build time via:
+//   go build -ldflags "-X main.buildCommit=$(git rev-parse --short HEAD)"
+var buildCommit = "unknown"
 
 var defaultModel = "codex/gpt-5.5"
 
@@ -166,6 +172,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 		"status":  "healthy",
 		"backend": "codex",
 		"version": version,
+		"commit":  buildCommit,
 	})
 }
 

--- a/cmd/relay-codex/main.go
+++ b/cmd/relay-codex/main.go
@@ -3,13 +3,13 @@
 // events into Claude shape — it emits OpenAI SSE directly from codex's
 // native JSONL events, and exploits codex's first-class features:
 //
-//   * Thread-based resume: when the client supplies a stable session_id,
+//   - Thread-based resume: when the client supplies a stable session_id,
 //     follow-up turns send only the latest user message via
 //     `codex exec resume <thread_id>` instead of re-shipping full history.
 //     Big token savings on long conversations.
-//   * Native multimodal attachments via `-i FILE`.
-//   * Reasoning effort via `-c model_reasoning_effort=`.
-//   * Multi-stage UX: command_execution surfaces as tool_calls, reasoning
+//   - Native multimodal attachments via `-i FILE`.
+//   - Reasoning effort via `-c model_reasoning_effort=`.
+//   - Multi-stage UX: command_execution surfaces as tool_calls, reasoning
 //     items as thinking deltas — visible in the UI even though codex doesn't
 //     stream individual tokens.
 package main
@@ -36,7 +36,8 @@ import (
 var version = "1.1.7"
 
 // buildCommit is stamped at build time via:
-//   go build -ldflags "-X main.buildCommit=$(git rev-parse --short HEAD)"
+//
+//	go build -ldflags "-X main.buildCommit=$(git rev-parse --short HEAD)"
 var buildCommit = "unknown"
 
 var defaultModel = "codex/gpt-5.5"

--- a/cmd/relay-codex/main.go
+++ b/cmd/relay-codex/main.go
@@ -31,7 +31,8 @@ import (
 	"clawrelay-api/pkg/sessions"
 )
 
-// version 1.1.6 被生产二进制占用但源码从未入库（版本漂移事故），跳到 1.1.7
+// version 1.1.6 被生产二进制占用但源码从未入库（版本漂移事故）；本分支合入了
+// 该幽灵 1.1.6 的源码内容（usage 跨轮差分，PR #27），正式版本号为 1.1.7，
 // 以保证线上版本号可比较；buildCommit 让 /health 能定位构建源。
 var version = "1.1.7"
 
@@ -59,6 +60,7 @@ var allowedOrigins = []string{
 var (
 	sessionStore *sessions.Store
 	threads      *threadMap
+	meter        *usageMeter
 	stats        = openai.NewStats()
 )
 
@@ -235,6 +237,7 @@ func main() {
 	sessionStore = sessions.New(*sessionsDir)
 	sessionStore.StartCleanup(72*time.Hour, 1*time.Hour)
 	threads = newThreadMap(sessionStore.AbsDir())
+	meter = newUsageMeter(sessionStore.AbsDir())
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/chat/completions", chatCompletionsHandler)

--- a/cmd/relay-codex/main.go
+++ b/cmd/relay-codex/main.go
@@ -137,10 +137,15 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
 
 	sessionStore.LogRequest(req.SessionID, &req)
 
+	// Retry closure for the dead-thread signature (`codex exec resume` of a
+	// vanished rollout exits 1 with empty stdout): forget the binding and
+	// rebuild the input as a fresh session replaying full history.
+	rebuildFresh := newRebuildFresh(threads, &req, model, sessionDir)
+
 	if req.Stream {
-		handleStreamResponse(w, r, input, chatID, created, model, includeUsage, req.WorkingDir, req.EnvVars, req.SessionID)
+		handleStreamResponse(w, r, input, chatID, created, model, includeUsage, req.WorkingDir, req.EnvVars, req.SessionID, rebuildFresh)
 	} else {
-		handleNonStreamResponse(w, r, input, chatID, created, model, req.WorkingDir, req.EnvVars, req.SessionID)
+		handleNonStreamResponse(w, r, input, chatID, created, model, req.WorkingDir, req.EnvVars, req.SessionID, rebuildFresh)
 	}
 }
 

--- a/cmd/relay-codex/stream.go
+++ b/cmd/relay-codex/stream.go
@@ -201,9 +201,7 @@ probe:
 		case "thread.started":
 			threadIDSeen = ev.ThreadID
 			log.Printf("[CODEX] thread_id=%s session_id=%s", ev.ThreadID, sessionID)
-			if sessionID != "" {
-				threads.Set(sessionID, ev.ThreadID)
-			}
+			rebindThread(sessionID, ev.ThreadID)
 
 		case "turn.started":
 			// no-op
@@ -248,9 +246,9 @@ probe:
 
 		case "turn.completed":
 			if ev.Usage != nil {
-				input, output, cacheRead := mapUsage(ev.Usage)
+				input, output, cacheRead := turnUsage(sessionID, ev.Usage)
 				stats.Record(model, input, output, 0, cacheRead, 0)
-				log.Printf("Token usage: model=%s input=%d output=%d cache_read=%d (codex)",
+				log.Printf("Token usage: model=%s input=%d output=%d cache_read=%d (codex, per-turn)",
 					model, input, output, cacheRead)
 				streamUsage = openai.BuildUsageInfo(input, output, cacheRead, 0)
 			}
@@ -264,18 +262,23 @@ probe:
 			log.Printf("[CODEX ERROR] %s", errMsg)
 			// CODEX-3: some codex versions attach usage to the failure event.
 			// Record it when present so failed turns still get metered; most
-			// failures carry no usage and that's fine (best-effort).
+			// failures carry no usage and that's fine (best-effort). The
+			// figures are thread-cumulative like any other, so they go
+			// through the same per-turn diff (PR #27).
 			if ev.Usage != nil {
-				inp, out, cr := mapUsage(ev.Usage)
+				inp, out, cr := turnUsage(sessionID, ev.Usage)
 				stats.Record(model, inp, out, 0, cr, 0)
 				streamUsage = openai.BuildUsageInfo(inp, out, cr, 0)
 			}
 			// If a resume failed because the thread is gone, drop the stale
 			// binding so the next turn starts fresh. Verified real-world text
 			// is "no rollout found for thread id ..." — it contains neither
-			// "session" nor a stable code, hence the three-noun match.
+			// "session" nor a stable code, hence the three-noun match. The
+			// usage baseline is tied to that thread's cumulative counter, so
+			// drop it too.
 			if sessionID != "" && input.IsResume && isStaleThreadErr(errMsg) {
 				threads.Forget(sessionID)
+				meter.Forget(sessionID)
 			}
 			textDelta("\n\n[codex error] " + errMsg)
 			emittedAnyContent = true
@@ -389,9 +392,7 @@ func handleNonStreamResponse(w http.ResponseWriter, r *http.Request, input codex
 			switch ev.Type {
 			case "thread.started":
 				threadIDSeen = ev.ThreadID
-				if sessionID != "" {
-					threads.Set(sessionID, ev.ThreadID)
-				}
+				rebindThread(sessionID, ev.ThreadID)
 			case "item.completed":
 				if ev.Item == nil {
 					continue
@@ -401,7 +402,7 @@ func handleNonStreamResponse(w http.ResponseWriter, r *http.Request, input codex
 				}
 			case "turn.completed":
 				if ev.Usage != nil {
-					inp, out, cr := mapUsage(ev.Usage)
+					inp, out, cr := turnUsage(sessionID, ev.Usage)
 					stats.Record(model, inp, out, 0, cr, 0)
 					usage = openai.BuildUsageInfo(inp, out, cr, 0)
 				}
@@ -412,12 +413,13 @@ func handleNonStreamResponse(w http.ResponseWriter, r *http.Request, input codex
 				}
 				// CODEX-3: failure events may still carry usage — meter them.
 				if ev.Usage != nil {
-					inp, out, cr := mapUsage(ev.Usage)
+					inp, out, cr := turnUsage(sessionID, ev.Usage)
 					stats.Record(model, inp, out, 0, cr, 0)
 					usage = openai.BuildUsageInfo(inp, out, cr, 0)
 				}
 				if sessionID != "" && input.IsResume && isStaleThreadErr(errorMsg) {
 					threads.Forget(sessionID)
+					meter.Forget(sessionID)
 				}
 			}
 		}
@@ -561,13 +563,16 @@ func abortCodexAndHarvest(cmd *exec.Cmd, lines <-chan string, model, sessionID s
 				switch ev.Type {
 				case "thread.started":
 					// Bind even during abort so the NEXT turn can resume this
-					// thread instead of replaying the whole history.
-					if sessionID != "" && ev.ThreadID != "" {
-						threads.Set(sessionID, ev.ThreadID)
-					}
+					// thread instead of replaying the whole history (rebind
+					// drops a foreign baseline if the thread rotated).
+					rebindThread(sessionID, ev.ThreadID)
 				case "turn.completed":
 					if ev.Usage != nil {
-						inp, out, cr := mapUsage(ev.Usage)
+						// Same per-turn diff as the foreground paths: the
+						// harvested figures are thread-cumulative, and going
+						// through turnUsage also advances the baseline so the
+						// NEXT turn doesn't re-count this one.
+						inp, out, cr := turnUsage(sessionID, ev.Usage)
 						stats.Record(model, inp, out, 0, cr, 0)
 						log.Printf("Token usage: model=%s input=%d output=%d cache_read=%d (codex, harvested after client abort)",
 							model, inp, out, cr)
@@ -576,6 +581,46 @@ func abortCodexAndHarvest(cmd *exec.Cmd, lines <-chan string, model, sessionID s
 			}
 		}
 	}()
+}
+
+// rebindThread records the codex thread_id for a session. If codex rotated to a
+// DIFFERENT thread (a resume that silently started a fresh thread instead of
+// erroring), the old usage baseline is foreign — the new thread's cumulative
+// counter restarts from zero — so drop it before rebinding, otherwise the next
+// turn would diff against a stale baseline and mis-bill. No-op when meter is nil
+// (handler invoked without main()'s init, e.g. tests).
+//
+// The Get-then-Set is not atomic, but turns for one session are effectively
+// serial (a conversation is request/response, and codex can't resume one thread
+// concurrently), so the rotation-during-concurrent-turn window is not a concern
+// in practice.
+func rebindThread(sessionID, threadID string) {
+	if sessionID == "" || threadID == "" {
+		return
+	}
+	if meter != nil {
+		if prev := threads.Get(sessionID); prev != "" && prev != threadID {
+			meter.Forget(sessionID)
+		}
+	}
+	threads.Set(sessionID, threadID)
+}
+
+// turnUsage resolves one turn's reportable (input, output, cache_read) from
+// codex's reported usage. codex reports thread-cumulative totals on resume, so
+// the meter diffs against the session's baseline to recover this turn's figure;
+// without that diff a resumed thread's usage climbs monotonically and every turn
+// re-counts all earlier turns.
+//
+// Assumes exactly one turn.completed per request (codex's `exec` contract): each
+// call advances the persisted baseline, so multiple turn.completed in one request
+// would each bill their own delta correctly but only the last would reach the
+// client's usage chunk.
+func turnUsage(sessionID string, u *codexUsage) (input, output, cacheRead int) {
+	if meter == nil { // defensive: handler invoked without main()'s init (tests)
+		return mapUsage(u)
+	}
+	return meter.perTurn(sessionID, *u)
 }
 
 // mapUsage converts codex's usage shape to the (input, output, cache_read)

--- a/cmd/relay-codex/stream.go
+++ b/cmd/relay-codex/stream.go
@@ -24,11 +24,60 @@ import (
 //   item.completed reasoning→ thinking delta with the reasoning text
 //   turn.completed          → finish_reason chunk + usage chunk
 //   error / turn.failed     → server_error response and stream end
-func handleStreamResponse(w http.ResponseWriter, r *http.Request, input codexInput, chatID string, created int64, model string, includeUsage bool, workingDir string, envVars map[string]string, sessionID string) {
-	cmd, lines, err := launchCodex(input, workingDir, envVars)
+//
+// rebuildFresh drops the stale thread binding and rebuilds the input as a
+// fresh full-history session; it is invoked when a resume dies with zero
+// stdout output (see the first-line probe below).
+func handleStreamResponse(w http.ResponseWriter, r *http.Request, input codexInput, chatID string, created int64, model string, includeUsage bool, workingDir string, envVars map[string]string, sessionID string, rebuildFresh func() codexInput) {
+	cmd, lines, waitErr, err := launchCodex(input, workingDir, envVars)
 	if err != nil {
 		openai.WriteError(w, http.StatusInternalServerError, "server_error", err.Error())
 		return
+	}
+
+	// ---- First-line probe (CODEX-1) ----------------------------------------
+	// SSE headers are NOT written yet, so we can still answer with a real HTTP
+	// error. Known failure mode (verified empirically): resuming a thread whose
+	// rollout file is gone (~/.codex/sessions cleaned, container rebuilt) makes
+	// codex exit(1) with COMPLETELY EMPTY stdout — the "no rollout found for
+	// thread id ..." text goes to stderr only, so no "error" event ever arrives
+	// and the old code streamed a fake empty success. We detect that as "lines
+	// closed before the first line", forget the dead binding and retry once as
+	// a fresh session with the full history replayed.
+	var firstLine string
+	haveFirst := false
+probe:
+	for attempt := 0; ; attempt++ {
+		select {
+		case <-r.Context().Done():
+			proc.KillGroup(cmd)    // client gone before first byte: nothing to harvest
+			proc.DrainLines(lines) // unblock producer so it reaches cmd.Wait()
+			return
+		case l, ok := <-lines:
+			if ok {
+				firstLine, haveFirst = l, true
+				break probe
+			}
+			// Zero stdout output: codex died before emitting anything.
+			werr := waitErr()
+			if input.IsResume && rebuildFresh != nil && attempt == 0 {
+				log.Printf("[CODEX] resume produced no output (exit err: %v) — forgetting stale thread for session_id=%s, retrying as fresh session", werr, sessionID)
+				input = rebuildFresh()
+				log.Printf("codex retry args: %v (stdin %d bytes)", input.Args, len(input.Stdin))
+				cmd, lines, waitErr, err = launchCodex(input, workingDir, envVars)
+				if err != nil {
+					openai.WriteError(w, http.StatusInternalServerError, "server_error", err.Error())
+					return
+				}
+				continue
+			}
+			msg := "codex produced no output"
+			if werr != nil {
+				msg += ": " + werr.Error()
+			}
+			openai.WriteError(w, http.StatusInternalServerError, "server_error", msg)
+			return
+		}
 	}
 
 	// Disconnect handling is inline in the processLines loop below (single
@@ -120,33 +169,17 @@ func handleStreamResponse(w http.ResponseWriter, r *http.Request, input codexInp
 	var threadIDSeen string
 	turnFailed := false
 	emittedAnyContent := false
+	sawEvent := false // any successfully parsed JSONL event
 
-processLines:
-	for {
-		var line string
-		var ok bool
-		select {
-		case <-r.Context().Done():
-			proc.KillGroup(cmd)    // disconnect: process is still running, safe to kill
-			proc.DrainLines(lines) // unblock producer so it reaches cmd.Wait()
-			return
-		case <-heartbeat.C:
-			fmt.Fprintf(w, ": keepalive\n\n")
-			flusher.Flush()
-			continue
-		case line, ok = <-lines:
-			if !ok {
-				break processLines
-			}
-		}
-		line = strings.TrimSpace(line)
+	handleLine := func(raw string) {
+		line := strings.TrimSpace(raw)
 		if line == "" || !strings.HasPrefix(line, "{") {
 			// codex sometimes writes non-JSON lines (banner, error logs) to
 			// stdout. Skip silently rather than confusing the client.
 			if line != "" {
 				log.Printf("[CODEX NON-JSON] %s", line)
 			}
-			continue
+			return
 		}
 
 		log.Printf("[CODEX RAW] %s", openai.Truncate(line, 500))
@@ -154,8 +187,9 @@ processLines:
 		var ev codexEvent
 		if err := json.Unmarshal([]byte(line), &ev); err != nil {
 			log.Printf("[CODEX PARSE ERR] %v: %s", err, line)
-			continue
+			return
 		}
+		sawEvent = true
 
 		switch ev.Type {
 		case "thread.started":
@@ -170,7 +204,7 @@ processLines:
 
 		case "item.started":
 			if ev.Item == nil {
-				continue
+				return
 			}
 			if ev.Item.Type == "command_execution" {
 				// Surface to client as a tool_call so the UI can render
@@ -181,7 +215,7 @@ processLines:
 
 		case "item.completed":
 			if ev.Item == nil {
-				continue
+				return
 			}
 			switch ev.Item.Type {
 			case "agent_message":
@@ -222,12 +256,58 @@ processLines:
 				errMsg = string(ev.Error)
 			}
 			log.Printf("[CODEX ERROR] %s", errMsg)
-			// If a resume failed because the thread is gone, drop the
-			// stale binding so the next turn starts fresh.
-			if sessionID != "" && input.IsResume && strings.Contains(errMsg, "session") {
+			// CODEX-3: some codex versions attach usage to the failure event.
+			// Record it when present so failed turns still get metered; most
+			// failures carry no usage and that's fine (best-effort).
+			if ev.Usage != nil {
+				inp, out, cr := mapUsage(ev.Usage)
+				stats.Record(model, inp, out, 0, cr, 0)
+				streamUsage = openai.BuildUsageInfo(inp, out, cr, 0)
+			}
+			// If a resume failed because the thread is gone, drop the stale
+			// binding so the next turn starts fresh. Verified real-world text
+			// is "no rollout found for thread id ..." — it contains neither
+			// "session" nor a stable code, hence the three-noun match.
+			if sessionID != "" && input.IsResume && isStaleThreadErr(errMsg) {
 				threads.Forget(sessionID)
 			}
 			textDelta("\n\n[codex error] " + errMsg)
+			emittedAnyContent = true
+		}
+	}
+
+	// The probed first line must flow through the same pipeline as the rest.
+	if haveFirst {
+		handleLine(firstLine)
+	}
+
+processLines:
+	for {
+		select {
+		case <-r.Context().Done():
+			// CODEX-2: client disconnected mid-turn. SIGINT + background
+			// harvest instead of an immediate SIGKILL, so a late
+			// turn.completed usage / thread.started binding isn't lost.
+			abortCodexAndHarvest(cmd, lines, model, sessionID)
+			return
+		case <-heartbeat.C:
+			fmt.Fprintf(w, ": keepalive\n\n")
+			flusher.Flush()
+		case line, ok := <-lines:
+			if !ok {
+				break processLines
+			}
+			handleLine(line)
+		}
+	}
+
+	// CODEX-5 fallback: headers are already written so we can't switch to an
+	// HTTP error anymore. If the whole stream produced no parseable event and
+	// the process exited abnormally (e.g. crashed after the first non-JSON
+	// banner line), surface it as visible text instead of a fake empty success.
+	if !sawEvent {
+		if werr := waitErr(); werr != nil {
+			textDelta("⚠️ [codex] 进程异常退出: " + werr.Error())
 			emittedAnyContent = true
 		}
 	}
@@ -257,67 +337,110 @@ processLines:
 }
 
 // handleNonStreamResponse runs codex to completion and returns one OpenAI
-// chat.completion JSON.
-func handleNonStreamResponse(w http.ResponseWriter, r *http.Request, input codexInput, chatID string, created int64, model string, workingDir string, envVars map[string]string, sessionID string) {
-	cmd, lines, err := launchCodex(input, workingDir, envVars)
+// chat.completion JSON. Like the stream path, a resume that dies with zero
+// stdout output (dead thread rollout) is retried once as a fresh session via
+// rebuildFresh (CODEX-1).
+func handleNonStreamResponse(w http.ResponseWriter, r *http.Request, input codexInput, chatID string, created int64, model string, workingDir string, envVars map[string]string, sessionID string, rebuildFresh func() codexInput) {
+	cmd, lines, waitErr, err := launchCodex(input, workingDir, envVars)
 	if err != nil {
 		openai.WriteError(w, http.StatusInternalServerError, "server_error", err.Error())
 		return
 	}
 
+	// Note: WatchDisconnect captures the ORIGINAL lines channel; after a retry
+	// relaunch the handler itself keeps ranging over the new channel until the
+	// killed process closes it, so the producer never wedges. getCmd is a
+	// closure so the watcher always signals the current child.
 	defer proc.WatchDisconnect(r.Context(), func() *exec.Cmd { return cmd }, lines)()
 
 	var (
-		fullText  strings.Builder
-		usage     *openai.UsageInfo
-		errorMsg  string
+		fullText     strings.Builder
+		usage        *openai.UsageInfo
+		errorMsg     string
 		threadIDSeen string
 	)
 
-	for line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" || !strings.HasPrefix(line, "{") {
-			if line != "" {
-				log.Printf("[CODEX NON-JSON] %s", line)
-			}
-			continue
-		}
-		log.Printf("[CODEX RAW] %s", openai.Truncate(line, 500))
+	for attempt := 0; ; attempt++ {
+		sawEvent := false // any successfully parsed JSONL event this run
 
-		var ev codexEvent
-		if err := json.Unmarshal([]byte(line), &ev); err != nil {
-			log.Printf("[CODEX PARSE ERR] %v: %s", err, line)
-			continue
-		}
-
-		switch ev.Type {
-		case "thread.started":
-			threadIDSeen = ev.ThreadID
-			if sessionID != "" {
-				threads.Set(sessionID, ev.ThreadID)
-			}
-		case "item.completed":
-			if ev.Item == nil {
+		for line := range lines {
+			line = strings.TrimSpace(line)
+			if line == "" || !strings.HasPrefix(line, "{") {
+				if line != "" {
+					log.Printf("[CODEX NON-JSON] %s", line)
+				}
 				continue
 			}
-			if ev.Item.Type == "agent_message" && ev.Item.Text != "" {
-				fullText.WriteString(ev.Item.Text)
+			log.Printf("[CODEX RAW] %s", openai.Truncate(line, 500))
+
+			var ev codexEvent
+			if err := json.Unmarshal([]byte(line), &ev); err != nil {
+				log.Printf("[CODEX PARSE ERR] %v: %s", err, line)
+				continue
 			}
-		case "turn.completed":
-			if ev.Usage != nil {
-				inp, out, cr := mapUsage(ev.Usage)
-				stats.Record(model, inp, out, 0, cr, 0)
-				usage = openai.BuildUsageInfo(inp, out, cr, 0)
-			}
-		case "error", "turn.failed":
-			errorMsg = ev.Message
-			if errorMsg == "" && len(ev.Error) > 0 {
-				errorMsg = string(ev.Error)
-			}
-			if sessionID != "" && input.IsResume && strings.Contains(errorMsg, "session") {
-				threads.Forget(sessionID)
+			sawEvent = true
+
+			switch ev.Type {
+			case "thread.started":
+				threadIDSeen = ev.ThreadID
+				if sessionID != "" {
+					threads.Set(sessionID, ev.ThreadID)
+				}
+			case "item.completed":
+				if ev.Item == nil {
+					continue
+				}
+				if ev.Item.Type == "agent_message" && ev.Item.Text != "" {
+					fullText.WriteString(ev.Item.Text)
+				}
+			case "turn.completed":
+				if ev.Usage != nil {
+					inp, out, cr := mapUsage(ev.Usage)
+					stats.Record(model, inp, out, 0, cr, 0)
+					usage = openai.BuildUsageInfo(inp, out, cr, 0)
+				}
+			case "error", "turn.failed":
+				errorMsg = ev.Message
+				if errorMsg == "" && len(ev.Error) > 0 {
+					errorMsg = string(ev.Error)
+				}
+				// CODEX-3: failure events may still carry usage — meter them.
+				if ev.Usage != nil {
+					inp, out, cr := mapUsage(ev.Usage)
+					stats.Record(model, inp, out, 0, cr, 0)
+					usage = openai.BuildUsageInfo(inp, out, cr, 0)
+				}
+				if sessionID != "" && input.IsResume && isStaleThreadErr(errorMsg) {
+					threads.Forget(sessionID)
+				}
 			}
 		}
+
+		if sawEvent {
+			break
+		}
+
+		// Zero parseable output: same dead-thread signature as the stream
+		// path (codex exit=1, stdout empty, error only on stderr).
+		werr := waitErr()
+		if input.IsResume && rebuildFresh != nil && attempt == 0 {
+			log.Printf("[CODEX] resume produced no output (exit err: %v) — forgetting stale thread for session_id=%s, retrying as fresh session (non-stream)", werr, sessionID)
+			input = rebuildFresh()
+			log.Printf("codex retry args: %v (stdin %d bytes)", input.Args, len(input.Stdin))
+			cmd2, lines2, waitErr2, lerr := launchCodex(input, workingDir, envVars)
+			if lerr != nil {
+				openai.WriteError(w, http.StatusInternalServerError, "server_error", lerr.Error())
+				return
+			}
+			cmd, lines, waitErr = cmd2, lines2, waitErr2
+			continue
+		}
+		msg := "codex produced no output"
+		if werr != nil {
+			msg += ": " + werr.Error()
+		}
+		openai.WriteError(w, http.StatusInternalServerError, "server_error", msg)
+		return
 	}
 
 	finishReason := "stop"
@@ -351,6 +474,79 @@ func handleNonStreamResponse(w http.ResponseWriter, r *http.Request, input codex
 	json.NewEncoder(w).Encode(resp)
 
 	_ = threadIDSeen
+}
+
+// isStaleThreadErr reports whether a codex error message indicates the
+// resumed thread no longer exists. Verified real-world text is
+// "no rollout found for thread id ..." — it contains NEITHER "session" nor a
+// stable error code, so we match the three nouns codex uses across versions
+// ("session" kept for older/other builds).
+func isStaleThreadErr(errMsg string) bool {
+	m := strings.ToLower(errMsg)
+	return strings.Contains(m, "session") ||
+		strings.Contains(m, "thread") ||
+		strings.Contains(m, "rollout")
+}
+
+// abortCodexAndHarvest handles a client disconnect mid-stream: SIGINT the
+// codex process group (giving the CLI a chance to flush terminal events),
+// then spend up to 8s in the background parsing whatever it still writes so
+// a turn.completed usage payload — and a late thread.started binding — are
+// not lost, before SIGKILLing whatever is left and draining the channel.
+//
+// NOTE: whether codex actually emits turn.completed (with usage) after a
+// SIGINT is UNVERIFIED (no codex credentials on the dev box); claude
+// demonstrably does. Strictly best-effort: if nothing harvestable arrives
+// within the window we only lose what was already lost, and the KillGroup
+// fallback guarantees no process leak either way.
+func abortCodexAndHarvest(cmd *exec.Cmd, lines <-chan string, model, sessionID string) {
+	if cmd != nil && cmd.Process != nil {
+		log.Printf("[CODEX ABORT] client disconnected, SIGINT process group pid=%d (session_id=%s)", cmd.Process.Pid, sessionID)
+	}
+	proc.InterruptGroup(cmd)
+	go func() {
+		deadline := time.NewTimer(8 * time.Second)
+		defer deadline.Stop()
+		for {
+			select {
+			case <-deadline.C:
+				log.Printf("[CODEX ABORT] harvest window expired for session_id=%s, killing process group", sessionID)
+				proc.KillGroup(cmd)
+				proc.DrainLines(lines)
+				return
+			case line, ok := <-lines:
+				if !ok {
+					// Producer closed the channel → child already reaped by
+					// cmd.Wait(). Do NOT KillGroup here: the PID may have been
+					// reused and we'd signal an unrelated process group.
+					return
+				}
+				line = strings.TrimSpace(line)
+				if line == "" || !strings.HasPrefix(line, "{") {
+					continue
+				}
+				var ev codexEvent
+				if json.Unmarshal([]byte(line), &ev) != nil {
+					continue
+				}
+				switch ev.Type {
+				case "thread.started":
+					// Bind even during abort so the NEXT turn can resume this
+					// thread instead of replaying the whole history.
+					if sessionID != "" && ev.ThreadID != "" {
+						threads.Set(sessionID, ev.ThreadID)
+					}
+				case "turn.completed":
+					if ev.Usage != nil {
+						inp, out, cr := mapUsage(ev.Usage)
+						stats.Record(model, inp, out, 0, cr, 0)
+						log.Printf("Token usage: model=%s input=%d output=%d cache_read=%d (codex, harvested after client abort)",
+							model, inp, out, cr)
+					}
+				}
+			}
+		}
+	}()
 }
 
 // mapUsage converts codex's usage shape to the (input, output, cache_read)

--- a/cmd/relay-codex/stream.go
+++ b/cmd/relay-codex/stream.go
@@ -60,6 +60,12 @@ probe:
 			}
 			// Zero stdout output: codex died before emitting anything.
 			werr := waitErr()
+			if r.Context().Err() != nil {
+				// 断连竞态：零输出可能是连接取消连带杀进程所致，不是死线程
+				// 签名 —— 不 Forget、不重试。
+				log.Printf("[CODEX] no output + client already gone; not retrying session_id=%s", sessionID)
+				return
+			}
 			if input.IsResume && rebuildFresh != nil && attempt == 0 {
 				log.Printf("[CODEX] resume produced no output (exit err: %v) — forgetting stale thread for session_id=%s, retrying as fresh session", werr, sessionID)
 				input = rebuildFresh()
@@ -421,12 +427,22 @@ func handleNonStreamResponse(w http.ResponseWriter, r *http.Request, input codex
 		}
 
 		// Zero parseable output: same dead-thread signature as the stream
-		// path (codex exit=1, stdout empty, error only on stderr).
+		// path (codex exit=1, stdout empty, error only on stderr). BUT a client
+		// disconnect produces the SAME signature via WatchDisconnect's
+		// KillGroup — that must NOT forget a valid binding nor relaunch an
+		// unwatched orphan run (CODEX review C1).
 		werr := waitErr()
+		if r.Context().Err() != nil {
+			log.Printf("[CODEX] no output because client disconnected (non-stream); not retrying session_id=%s", sessionID)
+			return
+		}
 		if input.IsResume && rebuildFresh != nil && attempt == 0 {
 			log.Printf("[CODEX] resume produced no output (exit err: %v) — forgetting stale thread for session_id=%s, retrying as fresh session (non-stream)", werr, sessionID)
 			input = rebuildFresh()
 			log.Printf("codex retry args: %v (stdin %d bytes)", input.Args, len(input.Stdin))
+			// 旧进程已被 cmd.Wait 回收：重建窗口（附件解码+fork，可达几十 ms）内
+			// 若断连，WatchDisconnect 不能对可能已复用的旧 PID 发信号。
+			cmd = nil
 			cmd2, lines2, waitErr2, lerr := launchCodex(input, workingDir, envVars)
 			if lerr != nil {
 				openai.WriteError(w, http.StatusInternalServerError, "server_error", lerr.Error())
@@ -483,9 +499,22 @@ func handleNonStreamResponse(w http.ResponseWriter, r *http.Request, input codex
 // ("session" kept for older/other builds).
 func isStaleThreadErr(errMsg string) bool {
 	m := strings.ToLower(errMsg)
-	return strings.Contains(m, "session") ||
-		strings.Contains(m, "thread") ||
-		strings.Contains(m, "rollout")
+	// 主签名（实证）："no rollout found for thread id ..."
+	if strings.Contains(m, "no rollout found") {
+		return true
+	}
+	// 其余必须是「对象 + 不存在」的组合才算：单凭名词命中就 Forget 的话，
+	// Rust panic 文本（"thread '...' panicked"）、限流提示（"usage limit
+	// reached for this session"）这类瞬态错误会误删有效绑定，把可自愈故障
+	// 放大成不可逆的整会话上下文丢失。
+	gone := strings.Contains(m, "not found") ||
+		strings.Contains(m, "no longer exists") ||
+		strings.Contains(m, "does not exist") ||
+		strings.Contains(m, "missing") ||
+		strings.Contains(m, "expired")
+	return gone && (strings.Contains(m, "thread") ||
+		strings.Contains(m, "session") ||
+		strings.Contains(m, "rollout"))
 }
 
 // abortCodexAndHarvest handles a client disconnect mid-stream: SIGINT the

--- a/cmd/relay-codex/threadmap.go
+++ b/cmd/relay-codex/threadmap.go
@@ -59,19 +59,24 @@ func (t *threadMap) Get(sessionID string) string {
 }
 
 // Set binds a session_id to a codex thread_id and writes through to disk.
-// Idempotent; the on-disk path is created lazily.
+// The on-disk path is created lazily.
+//
+// Deliberately NO same-value short-circuit: codex keeps the same thread_id
+// for the whole conversation, and for bots that run with a working_dir no
+// attachments ever land in this session directory — so without the rewrite
+// the file's (and directory's) mtime would stay frozen at turn #1 and the
+// sessions store's age-based cleanup could reap the binding of a session
+// that is active every day. Rewriting the identical value each turn
+// refreshes the mtime and doubles as a liveness beacon for the cleanup
+// (second line of defense next to the cleanup's max-child-mtime check).
 func (t *threadMap) Set(sessionID, threadID string) {
 	if sessionID == "" || threadID == "" {
 		return
 	}
 
 	t.mu.Lock()
-	existing, had := t.memory[sessionID]
 	t.memory[sessionID] = threadID
 	t.mu.Unlock()
-	if had && existing == threadID {
-		return
-	}
 
 	dir := filepath.Join(t.rootDir, sessionID)
 	if err := os.MkdirAll(dir, 0755); err != nil {

--- a/cmd/relay-codex/threadmap_test.go
+++ b/cmd/relay-codex/threadmap_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// TestThreadMapSetRewritesFileForSameValue locks in the CODEX-4 double-fix:
+// Set must rewrite the on-disk binding even when the value is unchanged, so
+// the file's mtime acts as a liveness beacon for the sessions cleanup (codex
+// keeps one thread_id for the whole conversation, so without this the file
+// would never be touched after turn #1).
+func TestThreadMapSetRewritesFileForSameValue(t *testing.T) {
+	tm := newThreadMap(t.TempDir())
+	tm.Set("sess", "tid-1")
+
+	p := tm.path("sess")
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(p, old, old); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tm.Set("sess", "tid-1") // identical value — must still rewrite
+
+	after, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.ModTime().After(before.ModTime()) {
+		t.Fatalf("Set with identical value did not refresh mtime: before=%v after=%v",
+			before.ModTime(), after.ModTime())
+	}
+	if got := tm.Get("sess"); got != "tid-1" {
+		t.Fatalf("binding corrupted by rewrite: got %q", got)
+	}
+}
+
+// TestThreadMapForgetRemovesMemoryAndDisk: after Forget, both the in-process
+// cache and the on-disk file are gone, so Get returns "" (fresh session next).
+func TestThreadMapForgetRemovesMemoryAndDisk(t *testing.T) {
+	tm := newThreadMap(t.TempDir())
+	tm.Set("sess", "tid-dead")
+
+	tm.Forget("sess")
+
+	if got := tm.Get("sess"); got != "" {
+		t.Fatalf("expected empty binding after Forget, got %q", got)
+	}
+	if _, err := os.Stat(tm.path("sess")); !os.IsNotExist(err) {
+		t.Fatalf("codex_thread.txt should be removed after Forget, stat err=%v", err)
+	}
+}

--- a/cmd/relay-codex/usage_meter.go
+++ b/cmd/relay-codex/usage_meter.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// usageMeter converts codex's per-thread *cumulative* usage into per-turn
+// reportable usage.
+//
+// Why this exists: codex reports usage on every `turn.completed`, but the
+// figures are running totals for the whole thread, not the single turn. Because
+// we resume the same thread across requests (see threadMap), a long session's
+// raw input/output/cached counts climb monotonically — feeding them straight
+// into the chat log double-counts every earlier turn. In production (2026-06) a
+// 78-turn session inflated input ~40x (single turn reached 5.5M, far past any
+// model context window) before this was caught.
+//
+// Unlike relay-claude's in-process cumulativeMeter, the codex cumulative counter
+// lives in the *thread*, which outlives the relay process — threadMap persists
+// thread_id to disk and resumes it after restarts. So the baseline has to be
+// persisted per session too: otherwise a relay restart would diff against a zero
+// baseline and re-bill the whole thread once. The baseline file sits next to
+// codex_thread.txt under the session dir, so session cleanup reaps both
+// together — thread gone ⇒ baseline gone ⇒ next thread starts from zero on both
+// sides.
+//
+// Known accepted cost: the FIRST turn after this build is first deployed onto an
+// already-live thread has no baseline file yet, so it diffs against zero and
+// bills that thread's accumulated total as one turn (a one-off inflation per
+// active session, bounded to the backlog at deploy time). There is no way to
+// recover the true baseline without a prior turn, so this is accepted rather
+// than guarded; see TestUsageMeterEmptyBaselineInflatesOnce which pins it.
+
+// meterBaseline is the per-session high-water mark of the *reportable* cumulative
+// usage — already split into uncached-input / cache-read / output via mapUsage.
+// Diffing the derived split (rather than codex's raw total+cached, then
+// recombining) is what keeps the input/cache_read attribution correct when the
+// cached subset and the total move by different amounts across turns.
+type meterBaseline struct {
+	Uncached  int `json:"uncached_input_tokens"`
+	CacheRead int `json:"cache_read_tokens"`
+	Output    int `json:"output_tokens"`
+}
+
+type usageMeter struct {
+	mu      sync.Mutex
+	memory  map[string]meterBaseline // session_id → cumulative high-water baseline
+	rootDir string
+}
+
+func newUsageMeter(rootDir string) *usageMeter {
+	return &usageMeter{
+		memory:  make(map[string]meterBaseline),
+		rootDir: rootDir,
+	}
+}
+
+// deriveBaseline maps codex's raw cumulative usage to the reportable cumulative
+// split, reusing mapUsage so the total→(uncached,cacheRead) rule lives in one
+// place (and handles the malformed cached>total case the same way).
+func deriveBaseline(u codexUsage) meterBaseline {
+	input, output, cacheRead := mapUsage(&u)
+	return meterBaseline{Uncached: input, CacheRead: cacheRead, Output: output}
+}
+
+// perTurn returns this turn's reportable (input, output, cacheRead) given codex's
+// cumulative snapshot `cur`. With no session id there is no thread reuse, so the
+// snapshot is already per-turn and is returned as-is (just split).
+//
+// Otherwise it diffs the derived cumulative split against the session's stored
+// baseline, flooring each field at zero, and advances the baseline to the
+// per-field high-water mark. Flooring + high-water (rather than a "cur < last ⇒
+// emit the whole cur as one turn" reset) keeps totals correct under the two ways
+// last and cur can disagree WITHOUT a genuine counter reset:
+//
+//   - Out-of-order completion of two concurrent same-session turns: the earlier
+//     (smaller) snapshot floors to 0 instead of re-billing its full cumulative,
+//     and the high-water baseline stops it dragging the baseline backwards, so
+//     the running sum stays exact regardless of completion order.
+//   - One field dipping while others climb: we never bill a climbing field's
+//     entire cumulative just because a different field regressed.
+//
+// A genuine counter reset (a different/new thread) is handled upstream: thread
+// rotation calls Forget, zeroing the baseline so cur passes through as the turn.
+func (m *usageMeter) perTurn(sessionID string, cur codexUsage) (input, output, cacheRead int) {
+	b := deriveBaseline(cur)
+	if sessionID == "" {
+		return b.Uncached, b.Output, b.CacheRead
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	last, ok := m.memory[sessionID]
+	if !ok {
+		last = m.load(sessionID) // read-through from disk on first turn after a restart
+	}
+
+	input = max(b.Uncached-last.Uncached, 0)
+	output = max(b.Output-last.Output, 0)
+	cacheRead = max(b.CacheRead-last.CacheRead, 0)
+
+	// Advance the baseline to the per-field high-water mark so an out-of-order
+	// smaller snapshot can't pull it back and double-bill the next turn.
+	hi := meterBaseline{
+		Uncached:  max(b.Uncached, last.Uncached),
+		CacheRead: max(b.CacheRead, last.CacheRead),
+		Output:    max(b.Output, last.Output),
+	}
+	m.memory[sessionID] = hi
+	m.store(sessionID, hi)
+	return input, output, cacheRead
+}
+
+// Forget drops a session's baseline. Called alongside threadMap.Forget when the
+// codex thread is gone or rotated — the replacement thread restarts its
+// cumulative counter from zero, so the baseline must too.
+func (m *usageMeter) Forget(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	m.mu.Lock()
+	delete(m.memory, sessionID)
+	m.mu.Unlock()
+	_ = os.Remove(m.path(sessionID))
+}
+
+func (m *usageMeter) load(sessionID string) meterBaseline {
+	var b meterBaseline
+	data, err := os.ReadFile(m.path(sessionID))
+	if err != nil {
+		return b // no baseline yet (new session, or reaped by cleanup) — zero is correct
+	}
+	if err := json.Unmarshal(data, &b); err != nil {
+		// A corrupt baseline must NOT silently read as zero — that would re-bill
+		// the thread's whole cumulative as one turn (the very inflation this
+		// meter prevents). store() writes atomically so this should be
+		// unreachable barring external tampering/FS damage; surface it loudly so
+		// the one-off over-count is at least detectable.
+		log.Printf("[usageMeter] corrupt baseline %s: %v — treating as empty (turn may over-count once)", m.path(sessionID), err)
+		return meterBaseline{}
+	}
+	return b
+}
+
+func (m *usageMeter) store(sessionID string, b meterBaseline) {
+	dir := filepath.Join(m.rootDir, sessionID)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		log.Printf("[usageMeter] mkdir %s: %v — baseline not persisted, may re-bill after restart", dir, err)
+		return
+	}
+	data, err := json.Marshal(b)
+	if err != nil {
+		log.Printf("[usageMeter] marshal baseline for %s: %v", sessionID, err)
+		return
+	}
+	// Atomic write: a crash mid-write would otherwise leave a truncated file that
+	// load() can't parse. tmp+rename within the same dir is atomic on POSIX.
+	tmp := m.path(sessionID) + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		log.Printf("[usageMeter] write %s: %v — baseline not persisted, may re-bill after restart", tmp, err)
+		return
+	}
+	if err := os.Rename(tmp, m.path(sessionID)); err != nil {
+		log.Printf("[usageMeter] rename %s: %v — baseline not persisted", tmp, err)
+		_ = os.Remove(tmp)
+	}
+}
+
+func (m *usageMeter) path(sessionID string) string {
+	return filepath.Join(m.rootDir, sessionID, "codex_usage.json")
+}

--- a/cmd/relay-codex/usage_meter_test.go
+++ b/cmd/relay-codex/usage_meter_test.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// codex reports thread-cumulative usage on every turn; the meter must return
+// per-turn reportable figures (uncached input, output, cache_read), not totals.
+func TestUsageMeterDiffsCumulative(t *testing.T) {
+	m := newUsageMeter(t.TempDir())
+
+	// turn1 cumulative: total=100, cached=40, out=10 → uncached input=60.
+	in, out, cr := m.perTurn("s1", codexUsage{InputTokens: 100, CachedInputTokens: 40, OutputTokens: 10})
+	if in != 60 || out != 10 || cr != 40 {
+		t.Fatalf("turn1 = in:%d out:%d cr:%d, want 60/10/40 (first turn, zero baseline)", in, out, cr)
+	}
+
+	// turn2 cumulative: total=260, cached=90, out=35 → uncached=170; per-turn
+	// delta vs turn1's split: input 170-60=110, cache_read 90-40=50, out 35-10=25.
+	in, out, cr = m.perTurn("s1", codexUsage{InputTokens: 260, CachedInputTokens: 90, OutputTokens: 35})
+	if in != 110 || out != 25 || cr != 50 {
+		t.Fatalf("turn2 = in:%d out:%d cr:%d, want 110/25/50 (per-turn delta)", in, out, cr)
+	}
+}
+
+// An empty session id means no thread reuse — the snapshot is already per-turn,
+// just split into (uncached input, output, cache_read).
+func TestUsageMeterPassThroughNoSession(t *testing.T) {
+	m := newUsageMeter(t.TempDir())
+	in, out, cr := m.perTurn("", codexUsage{InputTokens: 500, CachedInputTokens: 200, OutputTokens: 50})
+	if in != 300 || out != 50 || cr != 200 {
+		t.Fatalf("no-session = in:%d out:%d cr:%d, want 300/50/200 (split, not diffed)", in, out, cr)
+	}
+}
+
+// A regression (smaller snapshot than the baseline) within a thread is anomalous
+// — every field must floor to zero, NOT emit the whole cur as one turn — and the
+// baseline must hold its high-water mark so a later real turn still diffs right.
+func TestUsageMeterFloorsRegression(t *testing.T) {
+	m := newUsageMeter(t.TempDir())
+	m.perTurn("s1", codexUsage{InputTokens: 1000, CachedInputTokens: 400, OutputTokens: 100}) // baseline derived {600,400,100}
+
+	in, out, cr := m.perTurn("s1", codexUsage{InputTokens: 120, CachedInputTokens: 30, OutputTokens: 12})
+	if in != 0 || out != 0 || cr != 0 {
+		t.Fatalf("regression = in:%d out:%d cr:%d, want all-zero (floored, not raw cur)", in, out, cr)
+	}
+
+	// Baseline must still be the high-water {600,400,100}, so the next real turn
+	// diffs against it. cur derived {660,440,110} → delta 60/10/40.
+	in, out, cr = m.perTurn("s1", codexUsage{InputTokens: 1100, CachedInputTokens: 440, OutputTokens: 110})
+	if in != 60 || out != 10 || cr != 40 {
+		t.Fatalf("after regression, next = in:%d out:%d cr:%d, want 60/10/40", in, out, cr)
+	}
+}
+
+// Two concurrent same-session turns completing OUT OF ORDER (larger cumulative
+// lands first) must still bill the correct total — the earlier snapshot floors
+// to zero, the high-water baseline keeps the sum exact regardless of order.
+func TestUsageMeterConcurrentOutOfOrder(t *testing.T) {
+	m := newUsageMeter(t.TempDir())
+	m.perTurn("s1", codexUsage{InputTokens: 1000, CachedInputTokens: 400, OutputTokens: 100}) // baseline {600,400,100}
+
+	in1, out1, cr1 := m.perTurn("s1", codexUsage{InputTokens: 1400, CachedInputTokens: 520, OutputTokens: 140}) // larger first
+	in2, out2, cr2 := m.perTurn("s1", codexUsage{InputTokens: 1200, CachedInputTokens: 460, OutputTokens: 120}) // smaller second
+
+	// Totals must equal high-water {880,520,140} minus baseline {600,400,100}.
+	if in1+in2 != 280 || out1+out2 != 40 || cr1+cr2 != 120 {
+		t.Fatalf("out-of-order totals = in:%d out:%d cr:%d, want 280/40/120", in1+in2, out1+out2, cr1+cr2)
+	}
+	if in2 != 0 || out2 != 0 || cr2 != 0 {
+		t.Fatalf("the smaller out-of-order snapshot = in:%d out:%d cr:%d, want all-zero (floored)", in2, out2, cr2)
+	}
+}
+
+// Deriving the split BEFORE diffing (not diffing raw total/cached then
+// recombining) keeps attribution correct when the cached subset and the total
+// move by different amounts: here total climbs while the cached cumulative dips,
+// and the whole increment must land in input — none of it lost.
+func TestUsageMeterDerivesBeforeDiff(t *testing.T) {
+	m := newUsageMeter(t.TempDir())
+	m.perTurn("s1", codexUsage{InputTokens: 100, CachedInputTokens: 80, OutputTokens: 10}) // baseline derived {uncached:20, cr:80, out:10}
+
+	// cur derived {uncached:190, cr:60, out:25}. input = 190-20 = 170; cache_read
+	// floors (60<80) to 0; output 25-10 = 15.
+	in, out, cr := m.perTurn("s1", codexUsage{InputTokens: 250, CachedInputTokens: 60, OutputTokens: 25})
+	if in != 170 || out != 15 || cr != 0 {
+		t.Fatalf("derive-before-diff = in:%d out:%d cr:%d, want 170/15/0 (no input lost to the cached dip)", in, out, cr)
+	}
+}
+
+// A single derived field dipping while others climb must floor only that field.
+func TestUsageMeterSingleFieldRegression(t *testing.T) {
+	m := newUsageMeter(t.TempDir())
+	m.perTurn("s1", codexUsage{InputTokens: 1000, CachedInputTokens: 900, OutputTokens: 100}) // derived {uncached:100, cr:900, out:100}
+
+	// cur derived {uncached:100, cr:910, out:90}: input delta 0, cache_read +10,
+	// output floors (90<100) to 0.
+	in, out, cr := m.perTurn("s1", codexUsage{InputTokens: 1010, CachedInputTokens: 910, OutputTokens: 90})
+	if in != 0 || out != 0 || cr != 10 {
+		t.Fatalf("single-field regression = in:%d out:%d cr:%d, want 0/0/10 (only output floored)", in, out, cr)
+	}
+}
+
+// The codex thread (and its cumulative counter) outlives the relay process, so
+// the baseline must survive a restart — a fresh meter reads it back from disk
+// and keeps diffing instead of re-counting the whole thread.
+func TestUsageMeterPersistsAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	m1 := newUsageMeter(dir)
+	m1.perTurn("s1", codexUsage{InputTokens: 300, CachedInputTokens: 100, OutputTokens: 30}) // baseline derived {200,100,30}
+
+	m2 := newUsageMeter(dir) // simulate relay restart: in-memory map is empty
+	in, out, cr := m2.perTurn("s1", codexUsage{InputTokens: 420, CachedInputTokens: 130, OutputTokens: 44})
+	if in != 90 || out != 14 || cr != 30 {
+		t.Fatalf("after restart = in:%d out:%d cr:%d, want 90/14/30 (baseline loaded from disk)", in, out, cr)
+	}
+}
+
+// Deploying this build onto an already-live thread leaves no baseline file, so
+// the first turn bills the whole accumulated cumulative once. This is an accepted
+// one-off cost (we can't recover the true baseline without a prior turn); pin it
+// so the behavior is intentional and visible, and confirm it self-corrects after.
+func TestUsageMeterEmptyBaselineInflatesOnce(t *testing.T) {
+	m := newUsageMeter(t.TempDir())
+
+	// derived uncached input = 5_000_000 - 2_000_000 = 3_000_000.
+	in, _, cr := m.perTurn("live", codexUsage{InputTokens: 5_000_000, CachedInputTokens: 2_000_000, OutputTokens: 100_000})
+	if in != 3_000_000 || cr != 2_000_000 {
+		t.Fatalf("first-turn-after-deploy = in:%d cr:%d, want 3_000_000/2_000_000 (accepted one-off)", in, cr)
+	}
+	in, _, _ = m.perTurn("live", codexUsage{InputTokens: 5_050_000, CachedInputTokens: 2_010_000, OutputTokens: 101_000})
+	if in != 40_000 { // derived 3_040_000 - 3_000_000
+		t.Fatalf("second turn input = %d, want 40_000 (self-corrected)", in)
+	}
+}
+
+// A corrupt/truncated baseline file (should be unreachable given atomic writes,
+// but possible via FS damage/tampering) must not panic and must not be read as a
+// partial number — it falls back to empty and recovers on the next turn.
+func TestUsageMeterCorruptBaseline(t *testing.T) {
+	dir := t.TempDir()
+	sessDir := filepath.Join(dir, "s1")
+	if err := os.MkdirAll(sessDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessDir, "codex_usage.json"), []byte("{\"uncached_input_tokens\":12"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newUsageMeter(dir)
+	in, _, _ := m.perTurn("s1", codexUsage{InputTokens: 300, CachedInputTokens: 100, OutputTokens: 30})
+	if in != 200 { // treated as empty baseline → derived uncached 300-100
+		t.Fatalf("corrupt baseline input = %d, want 200 (treated as empty, not partial)", in)
+	}
+	// The atomic store should have replaced the corrupt file with a valid one.
+	in, _, _ = m.perTurn("s1", codexUsage{InputTokens: 360, CachedInputTokens: 130, OutputTokens: 44})
+	if in != 30 { // derived uncached 230 - baseline 200
+		t.Fatalf("post-recovery input = %d, want 30", in)
+	}
+}
+
+// Forget drops the baseline so the replacement thread starts from zero.
+func TestUsageMeterForget(t *testing.T) {
+	dir := t.TempDir()
+	m := newUsageMeter(dir)
+	m.perTurn("s1", codexUsage{InputTokens: 500, CachedInputTokens: 200, OutputTokens: 50})
+
+	m.Forget("s1")
+
+	fresh := newUsageMeter(dir) // no in-memory cache; must not find a stale baseline
+	in, out, cr := fresh.perTurn("s1", codexUsage{InputTokens: 90, CachedInputTokens: 20, OutputTokens: 9})
+	if in != 70 || out != 9 || cr != 20 { // derived split of the raw snapshot, zero baseline
+		t.Fatalf("after Forget = in:%d out:%d cr:%d, want 70/9/20 (baseline cleared)", in, out, cr)
+	}
+}
+
+// When codex rotates a session to a different thread_id (resume silently started
+// a new thread), rebindThread must drop the usage baseline — the new thread's
+// counter restarts at zero, so the old baseline is foreign. A rebind to the SAME
+// thread must NOT drop it.
+func TestRebindThreadForgetsOnRotation(t *testing.T) {
+	dir := t.TempDir()
+	oldThreads, oldMeter := threads, meter
+	threads = newThreadMap(dir)
+	meter = newUsageMeter(dir)
+	defer func() { threads, meter = oldThreads, oldMeter }()
+
+	threads.Set("s1", "T1")
+	meter.perTurn("s1", codexUsage{InputTokens: 1000, CachedInputTokens: 400, OutputTokens: 100})
+
+	// Rotation: bind to a different thread → baseline must be forgotten.
+	rebindThread("s1", "T2")
+	if threads.Get("s1") != "T2" {
+		t.Fatalf("thread not rebound: got %q want T2", threads.Get("s1"))
+	}
+	in, out, cr := meter.perTurn("s1", codexUsage{InputTokens: 120, CachedInputTokens: 30, OutputTokens: 12})
+	if in != 90 || out != 12 || cr != 30 { // baseline forgotten → derived split of raw
+		t.Fatalf("after rotation = in:%d out:%d cr:%d, want 90/12/30 (baseline forgotten)", in, out, cr)
+	}
+
+	// Rebind to the SAME thread → baseline preserved, next turn diffs normally.
+	rebindThread("s1", "T2")
+	in, out, cr = meter.perTurn("s1", codexUsage{InputTokens: 200, CachedInputTokens: 50, OutputTokens: 20})
+	if in != 60 || out != 8 || cr != 20 { // derived {150,50,20} - baseline {90,30,12}
+		t.Fatalf("after same-thread rebind = in:%d out:%d cr:%d, want 60/8/20 (baseline preserved)", in, out, cr)
+	}
+}
+
+// turnUsage must not panic when the global meter is nil (a handler/test path that
+// didn't run main()); it falls back to mapping the raw usage.
+func TestTurnUsageNilMeterPassThrough(t *testing.T) {
+	oldMeter := meter
+	meter = nil
+	defer func() { meter = oldMeter }()
+
+	in, out, cr := turnUsage("s1", &codexUsage{InputTokens: 1000, CachedInputTokens: 400, OutputTokens: 100})
+	if in != 600 || out != 100 || cr != 400 { // raw mapUsage: 1000-400 / 100 / 400
+		t.Fatalf("nil-meter turnUsage = in:%d out:%d cr:%d, want 600/100/400 (raw mapUsage)", in, out, cr)
+	}
+}

--- a/pkg/openai/stats.go
+++ b/pkg/openai/stats.go
@@ -76,6 +76,51 @@ func (s *Stats) Record(model string, input, output, cacheCreation, cacheRead int
 	ms.CostUSD += costUSD
 }
 
+// TokenCounts is one model's share of a single turn, used by RecordTurn to
+// attribute sub-agent (Task tool) tokens to the model that actually consumed
+// them instead of lumping everything under the requested model.
+type TokenCounts struct {
+	Input         int
+	Output        int
+	CacheCreation int
+	CacheRead     int
+	CostUSD       float64
+}
+
+// RecordTurn registers one completed turn whose usage is split per actual
+// model (claude's result.modelUsage shape). The turn counts as ONE request,
+// attributed to requestModel; token/cost figures accrue to each real model's
+// row. An empty perModel map still counts the request.
+func (s *Stats) RecordTurn(requestModel string, perModel map[string]TokenCounts) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.requests++
+	rm, ok := s.perModel[requestModel]
+	if !ok {
+		rm = &ModelTokenStats{}
+		s.perModel[requestModel] = rm
+	}
+	rm.Requests++
+	for model, c := range perModel {
+		s.input += int64(c.Input)
+		s.output += int64(c.Output)
+		s.cacheCreation += int64(c.CacheCreation)
+		s.cacheRead += int64(c.CacheRead)
+		s.costUSD += c.CostUSD
+		ms, ok := s.perModel[model]
+		if !ok {
+			ms = &ModelTokenStats{}
+			s.perModel[model] = ms
+		}
+		ms.Input += int64(c.Input)
+		ms.Output += int64(c.Output)
+		ms.CacheCreation += int64(c.CacheCreation)
+		ms.CacheRead += int64(c.CacheRead)
+		ms.Total += int64(c.Input + c.Output + c.CacheCreation + c.CacheRead)
+		ms.CostUSD += c.CostUSD
+	}
+}
+
 // Snapshot returns a deep-copied view safe for marshaling.
 func (s *Stats) Snapshot() TokenStatsSnapshot {
 	s.mu.Lock()

--- a/pkg/openai/stats.go
+++ b/pkg/openai/stats.go
@@ -121,6 +121,33 @@ func (s *Stats) RecordTurn(requestModel string, perModel map[string]TokenCounts)
 	}
 }
 
+// RecordOrphanTokens accrues tokens/cost WITHOUT counting a request — for
+// late-arriving tail usage of a turn that was already counted (e.g. tokens a
+// V3 claude burned after its client disconnected, swept up at the next turn's
+// window start or at session teardown).
+func (s *Stats) RecordOrphanTokens(perModel map[string]TokenCounts) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for model, c := range perModel {
+		s.input += int64(c.Input)
+		s.output += int64(c.Output)
+		s.cacheCreation += int64(c.CacheCreation)
+		s.cacheRead += int64(c.CacheRead)
+		s.costUSD += c.CostUSD
+		ms, ok := s.perModel[model]
+		if !ok {
+			ms = &ModelTokenStats{}
+			s.perModel[model] = ms
+		}
+		ms.Input += int64(c.Input)
+		ms.Output += int64(c.Output)
+		ms.CacheCreation += int64(c.CacheCreation)
+		ms.CacheRead += int64(c.CacheRead)
+		ms.Total += int64(c.Input + c.Output + c.CacheCreation + c.CacheRead)
+		ms.CostUSD += c.CostUSD
+	}
+}
+
 // Snapshot returns a deep-copied view safe for marshaling.
 func (s *Stats) Snapshot() TokenStatsSnapshot {
 	s.mu.Lock()

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -53,6 +53,24 @@ func KillGroup(cmd *exec.Cmd) {
 	}
 }
 
+// InterruptGroup SIGINTs the entire process group of cmd, asking the CLI to
+// abort gracefully. Unlike KillGroup, a SIGINTed `claude` still emits a final
+// `result` event (subtype error_during_execution) whose modelUsage carries the
+// interrupted turn's real token counts — callers use this to account for
+// aborted turns before falling back to KillGroup.
+func InterruptGroup(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	pid := cmd.Process.Pid
+	if pid <= 0 {
+		return
+	}
+	if err := syscall.Kill(-pid, syscall.SIGINT); err != nil {
+		_ = cmd.Process.Signal(syscall.SIGINT)
+	}
+}
+
 // DrainLines drains the producer's output channel in the background so a
 // goroutine blocked on `lines <- ...` (consumer stopped reading) unblocks,
 // completes its scan loop and runs cmd.Wait(), preventing a <defunct> zombie.

--- a/pkg/sessions/store.go
+++ b/pkg/sessions/store.go
@@ -272,29 +272,49 @@ func (s *Store) cleanupOldSessions(maxAge time.Duration) {
 		return
 	}
 	cutoff := time.Now().Add(-maxAge)
+
+	// Effective last-activity per session = the NEWEST mtime across the
+	// session's .jsonl log, its attachment/binding directory, and that
+	// directory's direct children.
+	//
+	// Why not the directory's own mtime (the old behavior): relay-codex writes
+	// codex_thread.txt into the session dir on the first turn, and bots that
+	// run with a working_dir never stage attachments here — so the directory's
+	// mtime can stay frozen at turn #1 for a session that is active every day.
+	// Judging age by the dir mtime alone deleted live thread bindings (and,
+	// because each branch removed BOTH artifacts, even a freshly-appended
+	// .jsonl), silently breaking `codex exec resume` for active sessions.
+	// (threadMap.Set now also rewrites codex_thread.txt every turn to refresh
+	// its mtime — the two fixes back each other up.)
+	latest := make(map[string]time.Time)
+	bump := func(id string, t time.Time) {
+		if cur, ok := latest[id]; !ok || t.After(cur) {
+			latest[id] = t
+		}
+	}
 	for _, e := range entries {
 		name := e.Name()
-		var sessionID string
-		var modTime time.Time
-
-		if e.IsDir() {
-			sessionID = name
-			info, err := e.Info()
-			if err != nil {
-				continue
-			}
-			modTime = info.ModTime()
-		} else if strings.HasSuffix(name, ".jsonl") {
-			sessionID = strings.TrimSuffix(name, ".jsonl")
-			info, err := e.Info()
-			if err != nil {
-				continue
-			}
-			modTime = info.ModTime()
-		} else {
+		info, err := e.Info()
+		if err != nil {
 			continue
 		}
+		if e.IsDir() {
+			bump(name, info.ModTime())
+			children, err := os.ReadDir(filepath.Join(s.Dir, name))
+			if err != nil {
+				continue
+			}
+			for _, c := range children {
+				if ci, err := c.Info(); err == nil {
+					bump(name, ci.ModTime())
+				}
+			}
+		} else if strings.HasSuffix(name, ".jsonl") {
+			bump(strings.TrimSuffix(name, ".jsonl"), info.ModTime())
+		}
+	}
 
+	for sessionID, modTime := range latest {
 		if modTime.After(cutoff) {
 			continue
 		}

--- a/pkg/sessions/store_test.go
+++ b/pkg/sessions/store_test.go
@@ -1,0 +1,120 @@
+package sessions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// aged returns a timestamp comfortably older than the 72h test maxAge.
+func aged() time.Time { return time.Now().Add(-100 * time.Hour) }
+
+// TestCleanupKeepsSessionWithFreshChildFile locks in the CODEX-4 fix: a
+// session directory whose OWN mtime is frozen at turn #1 (codex_thread.txt
+// written once, attachments staged in the bot's working_dir instead) must NOT
+// be reaped as long as a direct child file is fresh.
+func TestCleanupKeepsSessionWithFreshChildFile(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+
+	sessDir := filepath.Join(dir, "active")
+	if err := os.MkdirAll(sessDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Fresh child (just written), then age the directory itself.
+	if err := os.WriteFile(filepath.Join(sessDir, "codex_thread.txt"), []byte("tid-1"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(sessDir, aged(), aged()); err != nil {
+		t.Fatal(err)
+	}
+	// Old sibling jsonl — must also survive because the SESSION is alive.
+	logPath := filepath.Join(dir, "active.jsonl")
+	if err := os.WriteFile(logPath, []byte("{}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(logPath, aged(), aged()); err != nil {
+		t.Fatal(err)
+	}
+
+	s.cleanupOldSessions(72 * time.Hour)
+
+	if _, err := os.Stat(filepath.Join(sessDir, "codex_thread.txt")); err != nil {
+		t.Fatalf("live thread binding was deleted: %v", err)
+	}
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("jsonl of a live session was deleted: %v", err)
+	}
+}
+
+// TestCleanupKeepsSessionWithFreshJsonl: old dir + old children but a fresh
+// .jsonl sibling (session logged recently) must survive — the old code's dir
+// branch would have removed both artifacts on the dir's mtime alone.
+func TestCleanupKeepsSessionWithFreshJsonl(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+
+	sessDir := filepath.Join(dir, "logfresh")
+	if err := os.MkdirAll(sessDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	child := filepath.Join(sessDir, "codex_thread.txt")
+	if err := os.WriteFile(child, []byte("tid-2"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{child, sessDir} {
+		if err := os.Chtimes(p, aged(), aged()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Fresh jsonl.
+	logPath := filepath.Join(dir, "logfresh.jsonl")
+	if err := os.WriteFile(logPath, []byte("{}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s.cleanupOldSessions(72 * time.Hour)
+
+	if _, err := os.Stat(sessDir); err != nil {
+		t.Fatalf("session dir with fresh jsonl sibling was deleted: %v", err)
+	}
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("fresh jsonl was deleted: %v", err)
+	}
+}
+
+// TestCleanupRemovesFullyStaleSession: when dir, children AND jsonl are all
+// past maxAge, everything is removed.
+func TestCleanupRemovesFullyStaleSession(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+
+	sessDir := filepath.Join(dir, "stale")
+	if err := os.MkdirAll(sessDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	child := filepath.Join(sessDir, "codex_thread.txt")
+	if err := os.WriteFile(child, []byte("tid-3"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(dir, "stale.jsonl")
+	if err := os.WriteFile(logPath, []byte("{}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Age child first, then dir (writing child bumps the dir mtime).
+	for _, p := range []string{child, logPath, sessDir} {
+		if err := os.Chtimes(p, aged(), aged()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s.cleanupOldSessions(72 * time.Hour)
+
+	if _, err := os.Stat(sessDir); !os.IsNotExist(err) {
+		t.Fatalf("stale session dir should be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("stale jsonl should be removed, stat err=%v", err)
+	}
+}


### PR DESCRIPTION
> **说明**：本 PR 合并了两部分工作：
> 1. 原 #26（token 用量统计全链路修复，因提交账号错误已关闭，内容完整迁移至此）；
> 2. 原 #27（幽灵 1.1.6 源码：codex resume thread usage 跨轮差分），已整体合入本分支（保留原作者提交 `wxkingstar`），#27 随本 PR 关闭。

---

## 背景

对 V1/V2/V3/codex 四条链路做了 token 用量统计全链路审查（多智能体审查 + 对抗验证 + 本机 CLI 实证），确认 26 处缺陷后系统性修复。目标：每轮对话的 token 用量在 SSE 结束前以 usage chunk 准确下发（下游 wuji_tools 落库 robot_chat_logs），`/v1/stats` 不再漏记/多记/错归属。

配套下游 MR：wuji_tools `fix/token-usage-downstream`（AskUserQuestion 两轮落库、NULL/0 口径统一等）。

## 实证基础（写进了代码注释）

- **SIGINT 后 claude 仍会 emit result**（subtype=error_during_execution）：bare usage 全 0，但 `modelUsage` 有真实值且每模型带 `costUSD` —— 中断轮收割记账的依据
- **持久进程** `modelUsage`/`total_cost_usd` 是进程级单调累计；**bare usage 是 per-turn 值**；`--resume` 重启后从零累计（claude 2.1.199 实测）
- ~~codex `turn.completed.usage` 是本轮增量（claude10 三轮探测）~~ **已被 #27 的生产证据推翻**：resume 场景下 usage 是 thread 累计值（78 轮会话 input 虚增 ~40 倍、单轮 5.5M）。三轮短探测未跑出足够长的 resume 链，属误判。本 PR 已统一改走 #27 的高水位差分（`turnUsage`）；若后续证实某些 codex 版本确为本轮增量，差分的失败模式也只是单轮少计，远优于累计多计。
- **codex resume 失效 thread**：exit=1、stdout 全空、错误只在 stderr（`no rollout found`）
- **transcript jsonl**：同一 assistant 消息拆 3-5 行、usage 原样重复、requestId 相同（必须去重，否则多记 3-5 倍）

## 改动

### V1（每请求 claude -p）
- AskUserQuestion / stop 断连改为 **SIGINT → 10s 限时收割 result → 记账 → SIGKILL 兜底**（原先直接 SIGKILL，该轮 token 三处全丢）
- stats 按 `modelUsage` **实际消费模型归属**（子代理 token 不再全记在请求模型名下），per-model costUSD；缺 costUSD 时回退 `total_cost_usd`
- 进程无 result 退出时补发 finish chunk（不再伪装正常收尾）；stdout scanner 1MB→8MB + 溢出告警

### V2（channel 持久进程）
- **cumulativeMeter 重写**：modelUsage 流差分 + bare 轮按 per-turn 入账并垫高基线（shape 翻转不再把整段累计当全量多记；bare 轮不再被下次差分双计）；逐字段负数钳制
- **被中断轮记账**：后台 drainer 收割 result 差分入 stats（原先被 baseline 静默吸收）；零增量轮补计请求数
- acquire **单飞**（并发首请求不再双 spawn 泄漏孤儿进程）+ 等待接入请求 ctx；模型热切后 stats 归属 spawn-time 模型；ephemeral 断连同样 interrupt+收割；deadCh/lines 双就绪加 500ms 宽限排空（select 伪随机丢 result）；收割窗口内保持 inflight 注册（SIGTERM 不留孤儿）

### V3（channelv3 交互式 PTY）— 从 100% 无数据到真实计量
- launch 时 `--session-id <uuid>` 固定 transcript 文件名，glob 定位 `~/.claude/projects/*/<uuid>.jsonl`
- **增量 tail + requestId 去重** 聚合每轮真实 usage（含 isSidechain 子代理行），SSE 结束前发 usage chunk（下游零改动即可落库）；`/v1/stats` 同步入账（含请求数）
- 全部终止路径覆盖：final reply / 进程死亡（含未流式）/ idle 超时 / cold-start 放弃 / 断连；stop 后的遗留 token 由 turn 开窗前 orphan sweep + kill/reap/evict 收尸 sweep 兜底入总账，**不污染下一轮的 usage chunk**
- 降级铁律：transcript 缺失/解析失败 → 不发 chunk（下游保持 NULL=未计量），绝不发假 0

### relay-codex
- **resume 死绑定检测**：首行探测（headers 前）发现零输出 → Forget + fresh 重试一次；彻底修复"每轮永久静默空回复"（原先 Forget 分支不可达）
- 断连误判防护：ctx 已取消的零输出不 Forget 不重试（否则销毁有效绑定 + 放跑无人监视的孤儿全量跑）
- stale 错误匹配收紧为「对象+不存在」组合（panic/限流文本不再误删绑定）；重建窗口置 nil cmd 防 PID 复用误杀；迟到 thread.started 不覆盖新绑定
- 断连 SIGINT 收割（best-effort，codex SIGINT 行为未实证已注明）；turn.failed 若带 usage 也入账；崩溃零事件不再伪装成功
- **sessions 72h cleanup 改按目录+子文件最大 mtime**（不再误删活跃长寿会话的 thread 绑定与日志）；threadMap.Set 每轮重写刷 mtime

### 版本 / 可观测
- relay-claude **2.0.2 → 2.0.3**，relay-codex **1.1.5 → 1.1.7**（跳过 1.1.6：该版本号被一个源码未入库的生产二进制占用，见下）
- `/health` 新增 `commit` 字段，构建时 `-ldflags "-X main.buildCommit=$(git rev-parse --short HEAD)"` 注入

## ⚠️ 需要人工跟进

1. **1.1.6 版本漂移**：生产 claude10/11 的 relay-codex 自报 1.1.6，但仓库无对应源码——请找回该构建的工作树补提交，或确认可被本分支覆盖
2. **生产 2.0.1 实例**：channel 模式下 2.0.1 无跨轮差分（每轮上报进程累计值，暴涨式多记），合并后请统一升级
3. **V3 `--session-id` 与 `--dangerously-load-development-channels` 组合**未实机验证（--help 层面为通用旗标），建议先在 QA/claude02 灰度确认 transcript 落在预期 uuid 文件
4. codex SIGINT 后是否 emit usage 未实证（无本地 auth），相关收割为 best-effort、失败无副作用

## 测试

- `go build ./... && go vet ./... && go test ./...` 全绿（新增/重写测试 30+ 用例：meter 差分与 shape 翻转回归、transcript 窗口/去重/rotation、stale 匹配、cleanup mtime、singleflight 等待）
- 多智能体对抗审查两轮：第一轮 26 项确认修复，第二轮对合并 diff 复审出 14 项回归/边界问题并全部修复（bare 轮双计、断连收割缺口、select 伪随机丢 result、死线程误判等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 合入 #27 的冲突解决与整合说明

#27 基于旧版 stream.go 打补丁，与本分支 Area C 的重构在 `cmd/relay-codex/{main.go,stream.go}` 有 5 处冲突，解决原则：**保留本分支的循环/重试骨架，嫁接 #27 的差分语义**：

| 冲突点 | 取舍 |
|---|---|
| 版本号（1.1.6 vs 1.1.7） | 保留 **1.1.7** + buildCommit；1.1.6 是幽灵版本（生产二进制占用、源码即 #27），main.go 注释已闭环 |
| `thread.started` 绑定 | 取 #27 的 `rebindThread()`（换 thread 自动 Forget 旧基线） |
| `turn.completed` 记账 | 取 #27 的 `turnUsage()` 差分 |
| 死线程检测 | 保留本分支 `isStaleThreadErr()`（实测报错 "no rollout found for thread id" 不含 "session"，#27 的 `Contains("session")` 匹配不到），叠加 #27 的 `meter.Forget()` |
| 循环结构 | 本分支骨架（sawEvent/重试/断连安全） |

**#27 原补丁没有覆盖、本次整合补齐的三处差分口径**（否则这些路径仍按累计值记账，#27 修的重复计费在这些路径原样复发）：
- CODEX-3 失败事件携带的 usage → `turnUsage()`
- `abortCodexAndHarvest` 断连后台收割 → `turnUsage()` + `rebindThread()`（顺带推进基线，防下一轮重复计）
- `newRebuildFresh` 死线程重建 → 追加 `meter.Forget()`（否则新 thread 从 0 计数被旧高水位基线压成 0，该 session 后续轮次全部漏计）

## 合并后验证清单（本机无 Go 工具链，未能本地编译）

- [ ] `go build ./... && go test ./cmd/relay-codex/ ./cmd/relay-claude/`
- [ ] claude10 两轮 resume 探测复核 usage 语义：第 2 轮 `turn.completed.usage.input` ≈ 本轮（增量）还是 ≈ 两轮之和（累计）——决定差分口径是否对所有 codex 版本成立
