### PR TITLE
fix(relay-claude/v1): ready 门控根治——提前发头+双看门狗+resume 嗅探不再吞错误 result (2.2.0)

### DIFF
--- a/cmd/relay-claude/channel_handler.go
+++ b/cmd/relay-claude/channel_handler.go
@@ -38,7 +38,8 @@ var channelQueuedPingInterval = 15 * time.Second
 func channelEmitErrClose(w http.ResponseWriter, flusher http.Flusher, chatID string, created int64, model, msg string) {
 	chunk := openai.ChatCompletionResponse{
 		ID: chatID, Object: "chat.completion.chunk", Created: created, Model: model,
-		Choices: []openai.ChatCompletionChoice{{Index: 0, Delta: openai.NewChatMessage("assistant", "⚠️ "+msg)}},
+		Choices:     []openai.ChatCompletionChoice{{Index: 0, Delta: openai.NewChatMessage("assistant", "⚠️ "+msg)}},
+		XRelayError: true,
 	}
 	data, _ := json.Marshal(chunk)
 	fmt.Fprintf(w, "data: %s\n\n", data)
@@ -46,7 +47,8 @@ func channelEmitErrClose(w http.ResponseWriter, flusher http.Flusher, chatID str
 	finish := "stop"
 	fin := openai.ChatCompletionResponse{
 		ID: chatID, Object: "chat.completion.chunk", Created: created, Model: model,
-		Choices: []openai.ChatCompletionChoice{{Index: 0, Delta: openai.NewChatMessage("", ""), FinishReason: &finish}},
+		Choices:     []openai.ChatCompletionChoice{{Index: 0, Delta: openai.NewChatMessage("", ""), FinishReason: &finish}},
+		XRelayError: true,
 	}
 	data, _ = json.Marshal(fin)
 	fmt.Fprintf(w, "data: %s\n\n", data)

--- a/cmd/relay-claude/main.go
+++ b/cmd/relay-claude/main.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -25,7 +26,7 @@ import (
 	"clawrelay-api/pkg/sessions"
 )
 
-var version = "2.1.0"
+var version = "2.2.0"
 
 // buildCommit is stamped at build time via:
 //
@@ -306,6 +307,15 @@ func main() {
 	if *model != "" {
 		defaultModel = *model
 		log.Printf("Default model set to: %s", defaultModel)
+	}
+
+	if v := os.Getenv("RELAY_FIRST_LINE_TIMEOUT_SECS"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			firstLineTimeout = time.Duration(secs) * time.Second
+			log.Printf("first-line watchdog timeout set to %s (RELAY_FIRST_LINE_TIMEOUT_SECS)", firstLineTimeout)
+		} else {
+			log.Printf("ignoring invalid RELAY_FIRST_LINE_TIMEOUT_SECS=%q", v)
+		}
 	}
 
 	if *proxy != "" {

--- a/cmd/relay-claude/process.go
+++ b/cmd/relay-claude/process.go
@@ -4,15 +4,27 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"clawrelay-api/pkg/openai"
 	"clawrelay-api/pkg/proc"
 )
+
+// firstLineTimeout bounds how long a freshly-started claude process may stay
+// completely silent on stdout. A CLI that hangs before its first stream-json
+// line (bad binary on PATH, wedged auto-updater, dead proxy) used to stall the
+// request until the client's own read timeout killed the connection; the
+// watchdog kills it instead so the failure is fast and visible. Must stay
+// below the upstream client's idle timeout (wuji-tools: sock_read=120s).
+// Overridable via RELAY_FIRST_LINE_TIMEOUT_SECS; package var so tests can
+// shorten it.
+var firstLineTimeout = 90 * time.Second
 
 // cleanEnv returns the current environment with CLAUDECODE removed (the
 // claude CLI uses this to detect being run inside another Claude session;
@@ -102,8 +114,10 @@ func buildClaudeArgs(req *openai.ChatCompletionRequest, model, prompt, systemPro
 // launchClaude starts a `claude` subprocess and returns its stdout-line
 // channel along with a stderr-completion signal. The channel closes after
 // cmd.Wait. sessErrCh receives true if the "No conversation found" stderr
-// marker was seen — used to drive the resume-retry path.
-func launchClaude(args []string, prompt, workingDir string, envVars map[string]string) (*exec.Cmd, <-chan string, <-chan bool, error) {
+// marker was seen — used to drive the resume-retry path. watchdogTimeout is
+// passed by value (callers snapshot firstLineTimeout synchronously) so the
+// watchdog goroutine never reads the package var concurrently.
+func launchClaude(args []string, prompt, workingDir string, envVars map[string]string, watchdogTimeout time.Duration) (*exec.Cmd, <-chan string, <-chan bool, error) {
 	cmd := exec.Command("claude", args...)
 	// Own process group so KillGroup can reap the whole tree (node wrapper +
 	// native claude binary) instead of orphaning the native child.
@@ -132,6 +146,12 @@ func launchClaude(args []string, prompt, workingDir string, envVars map[string]s
 	go func() {
 		defer stderrDone.Done()
 		s := bufio.NewScanner(stderrPipe)
+		// Same oversize-line guard as stdout: a single >64KB stderr line (node
+		// dumping a response body) would end the scan early, losing the
+		// "No conversation found" marker that gates the resume retry, and
+		// leaving the pipe undrained — a child blocked writing stderr never
+		// exits, so stdout never EOFs and the sniff stalls.
+		s.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
 		found := false
 		for s.Scan() {
 			line := s.Text()
@@ -140,7 +160,31 @@ func launchClaude(args []string, prompt, workingDir string, envVars map[string]s
 				found = true
 			}
 		}
+		if err := s.Err(); err != nil {
+			log.Printf("Claude stderr scanner error: %v", err)
+			io.Copy(io.Discard, stderrPipe) //nolint:errcheck // backstop drain
+		}
 		sessErrCh <- found
+	}()
+
+	// First-line watchdog: a CLI that never prints a single stdout line (bad
+	// binary hijacking PATH, wedged auto-updater, dead proxy — the claude04
+	// incident) used to hang the request until the upstream client's own read
+	// timeout killed the connection. Kill it ourselves so the failure is fast
+	// and carries a diagnosable error. Disarmed by the first scanned line, or
+	// by process exit (zero-output crash needs no kill).
+	firstLineSeen := make(chan struct{})
+	var disarmOnce sync.Once
+	disarm := func() { disarmOnce.Do(func() { close(firstLineSeen) }) }
+	go func() {
+		timer := time.NewTimer(watchdogTimeout)
+		defer timer.Stop()
+		select {
+		case <-firstLineSeen:
+		case <-timer.C:
+			log.Printf("first-line watchdog: claude silent on stdout for %s, killing process group (args=%q)", watchdogTimeout, args)
+			proc.KillGroup(cmd)
+		}
 	}()
 
 	lines := make(chan string, 128)
@@ -152,8 +196,14 @@ func launchClaude(args []string, prompt, workingDir string, envVars map[string]s
 		// bufio.ErrTooLong would silently truncate the stream mid-turn.
 		s.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
 		for s.Scan() {
+			disarm()
 			lines <- s.Text()
 		}
+		// stdout EOF: the process has closed stdout, the watchdog's job is
+		// over. Disarm BEFORE cmd.Wait() reaps the child — a timer firing in
+		// the reap window would KillGroup a possibly-recycled PID (the same
+		// hazard proc.WatchDisconnect defends against).
+		disarm()
 		if err := s.Err(); err != nil {
 			// bufio.ErrTooLong (line > 8MB) or a read error: the stream ends
 			// early and the caller may never see a result event (see
@@ -169,34 +219,122 @@ func launchClaude(args []string, prompt, workingDir string, envVars map[string]s
 	return cmd, lines, sessErrCh, nil
 }
 
+// lastOutputNote summarizes the trailing non-empty stdout line (node stack
+// traces, wrapper banners printed to stdout) for zero-event error messages —
+// otherwise the real failure text would be silently discarded and the error
+// would claim "no output" while output existed.
+func lastOutputNote(buffered []string) string {
+	for i := len(buffered) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(buffered[i])
+		if line == "" {
+			continue
+		}
+		return fmt.Sprintf("; last output: %s", openai.Truncate(line, 200))
+	}
+	return ""
+}
+
+// procHandle publishes the currently-running claude process to the HTTP
+// handler and coordinates cancellation with the producer goroutine, which may
+// still be launching (or, on the resume path, re-launching) processes when the
+// client disconnects. All access goes through the mutex: an unsynchronized
+// **exec.Cmd would be both a data race (the handler's pre-ready disconnect
+// read races the producer's assignment) and a TOCTOU — a --session-id retry
+// launched just after the handler aborted would become an unkillable orphan
+// running the user's full prompt to completion.
+type procHandle struct {
+	mu      sync.Mutex
+	cmd     *exec.Cmd
+	aborted bool
+}
+
+// publish records a freshly-launched process. Returns false when the handler
+// has already aborted — the caller must kill the newcomer and stop instead of
+// proceeding (this closes the launch-after-abort orphan window).
+func (h *procHandle) publish(cmd *exec.Cmd) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.aborted {
+		return false
+	}
+	h.cmd = cmd
+	return true
+}
+
+// abort marks the request as cancelled and returns the process to kill. A nil
+// return means the producer is between launches; its next publish will return
+// false and it kills the newcomer itself.
+func (h *procHandle) abort() *exec.Cmd {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.aborted = true
+	return h.cmd
+}
+
 // startClaudeStream wraps launchClaude with auto-retry on resume failure.
-// If --resume produced no real content (only init/system/result events), it
-// retries the whole command with --session-id instead.
+// If --resume produced no real content because the session is actually
+// missing (stderr marker), it retries the whole command with --session-id.
 //
-// ready signals when it is safe to write HTTP response headers. cmdPtr lets
-// the caller kill the process after ready fires.
-func startClaudeStream(args []string, prompt, workingDir string, envVars map[string]string) (<-chan string, <-chan error, **exec.Cmd) {
+// ready signals when claude produced its first usable output (or definitively
+// failed); the handler sends SSE headers before that and uses the returned
+// procHandle to kill the current process on disconnect.
+func startClaudeStream(args []string, prompt, workingDir string, envVars map[string]string) (<-chan string, <-chan error, *procHandle) {
 	lines := make(chan string, 128)
 	ready := make(chan error, 1)
-	var cmdHolder *exec.Cmd
-	cmdPtr := &cmdHolder
+	handle := &procHandle{}
+
+	// Snapshot synchronously: the goroutine below (and the watchdog goroutines
+	// it spawns) must not read the package var concurrently with anyone
+	// mutating it (tests).
+	watchdogTimeout := firstLineTimeout
 
 	go func() {
 		defer close(lines)
 
-		cmd, innerLines, sessErrCh, err := launchClaude(args, prompt, workingDir, envVars)
+		cmd, innerLines, sessErrCh, err := launchClaude(args, prompt, workingDir, envVars, watchdogTimeout)
 		if err != nil {
 			ready <- err
 			return
 		}
-		cmdHolder = cmd
+		if !handle.publish(cmd) {
+			proc.KillGroup(cmd)
+			go func() { <-sessErrCh }()
+			proc.DrainLines(innerLines)
+			ready <- fmt.Errorf("request cancelled during claude startup")
+			return
+		}
 
 		if hasArg(args, "--resume") {
+			// Sniff the resume run. Everything is buffered — never discarded:
+			// an early result event carries the error text (API error / rate
+			// limit / auth failure) and the turn's usage, and dropping it used
+			// to bypass the translator's error transparency and answer with a
+			// delayed empty 200 stream ("未生成文本回复" downstream).
 			var buffered []string
 			gotContent := false
-			shouldRetry := false
+			sawResult := false
 
-			for line := range innerLines {
+			// Sniff deadline: the first-line watchdog disarms on the very
+			// first stdout line, but a resume run prints its init event
+			// locally before any API call — a CLI that hangs after that (dead
+			// proxy, wedged retry loop) would stall the sniff forever, and the
+			// pre-ready keepalives now hide the stall from the client's own
+			// idle timeout. Bound the whole sniff with the same budget.
+			sniffTimer := time.NewTimer(watchdogTimeout)
+		sniff:
+			for {
+				var line string
+				var lok bool
+				select {
+				case line, lok = <-innerLines:
+				case <-sniffTimer.C:
+					log.Printf("resume sniff watchdog: no content/result within %s, killing process group (args=%q)", watchdogTimeout, args)
+					proc.KillGroup(cmd)
+					continue // the kill closes stdout shortly; drain to EOF
+				}
+				if !lok {
+					break sniff
+				}
 				buffered = append(buffered, line)
 				var evt struct {
 					Type string `json:"type"`
@@ -208,47 +346,75 @@ func startClaudeStream(args []string, prompt, workingDir string, envVars map[str
 					continue
 				}
 				if evt.Type == "result" {
-					shouldRetry = true
-					for range innerLines {
+					// Result before any content: the run is over. Buffer the
+					// remainder to EOF so nothing is lost.
+					sawResult = true
+					for line := range innerLines {
+						buffered = append(buffered, line)
 					}
-					break
+					break sniff
 				}
 				gotContent = true
-				break
+				break sniff
 			}
+			sniffTimer.Stop()
 
-			if !gotContent && !shouldRetry {
-				shouldRetry = true
-			}
-
-			if shouldRetry {
-				<-sessErrCh
-				log.Printf("Resume produced no content, retrying with --session-id")
-				retryArgs := replaceArg(args, "--resume", "--session-id")
-				cmd, innerLines, sessErrCh, err = launchClaude(retryArgs, prompt, workingDir, envVars)
-				if err != nil {
-					ready <- err
-					return
-				}
-				cmdHolder = cmd
+			if gotContent {
 				go func() { <-sessErrCh }()
-
-				firstLine, ok := <-innerLines
 				ready <- nil
-				if ok {
-					lines <- firstLine
-					for line := range innerLines {
-						lines <- line
-					}
+				for _, line := range buffered {
+					lines <- line
+				}
+				for line := range innerLines {
+					lines <- line
 				}
 				return
 			}
 
-			go func() { <-sessErrCh }()
-			ready <- nil
-			for _, line := range buffered {
-				lines <- line
+			// No content and innerLines closed → the process has exited, so
+			// the stderr verdict is available. Only an actually-missing session
+			// justifies the --session-id retry: retrying against an existing
+			// session re-runs the turn at best and produces a second empty
+			// stream at worst.
+			sessionMissing := <-sessErrCh
+			if !sessionMissing {
+				if sawResult {
+					log.Printf("Resume run ended with a result and no content (session exists); forwarding %d buffered event(s) instead of retrying", len(buffered))
+					ready <- nil
+					for _, line := range buffered {
+						lines <- line
+					}
+					return
+				}
+				ready <- fmt.Errorf("claude exited without a usable event%s (session exists; crash or first-line watchdog kill, check relay logs)", lastOutputNote(buffered))
+				return
 			}
+
+			log.Printf("Resume session not found, retrying with --session-id")
+			retryArgs := replaceArg(args, "--resume", "--session-id")
+			cmd, innerLines, sessErrCh, err = launchClaude(retryArgs, prompt, workingDir, envVars, watchdogTimeout)
+			if err != nil {
+				ready <- err
+				return
+			}
+			if !handle.publish(cmd) {
+				proc.KillGroup(cmd)
+				go func() { <-sessErrCh }()
+				proc.DrainLines(innerLines)
+				ready <- fmt.Errorf("request cancelled during claude resume retry")
+				return
+			}
+			go func() { <-sessErrCh }()
+
+			firstLine, ok := <-innerLines
+			if !ok {
+				// The retry also died silently. Surfacing the failure beats the
+				// old behavior (ready<-nil + empty 200 stream).
+				ready <- fmt.Errorf("claude --session-id retry exited without producing any output")
+				return
+			}
+			ready <- nil
+			lines <- firstLine
 			for line := range innerLines {
 				lines <- line
 			}
@@ -258,7 +424,7 @@ func startClaudeStream(args []string, prompt, workingDir string, envVars map[str
 		firstLine, ok := <-innerLines
 		if !ok {
 			go func() { <-sessErrCh }()
-			ready <- nil
+			ready <- fmt.Errorf("claude exited without producing any output (crash or first-line watchdog kill, check relay logs)")
 			return
 		}
 		go func() { <-sessErrCh }()
@@ -269,14 +435,14 @@ func startClaudeStream(args []string, prompt, workingDir string, envVars map[str
 		}
 	}()
 
-	return lines, ready, cmdPtr
+	return lines, ready, handle
 }
 
 // runClaude is the non-streaming counterpart: collects all events, the final
 // result text, and usage. Auto-retries with --session-id if --resume yields
 // no content.
 func runClaude(args []string, prompt, workingDir string, envVars map[string]string) (events []claudeEvent, lastText, result string, usage *openai.UsageInfo, rawUsage *claudeUsage, costUSD float64, err error) {
-	_, lines, sessErrCh, err := launchClaude(args, prompt, workingDir, envVars)
+	_, lines, sessErrCh, err := launchClaude(args, prompt, workingDir, envVars, firstLineTimeout)
 	if err != nil {
 		return
 	}
@@ -309,9 +475,12 @@ func runClaude(args []string, prompt, workingDir string, envVars map[string]stri
 		}
 	}
 
-	<-sessErrCh
-	if hasArg(args, "--resume") && lastText == "" && result == "" {
-		log.Printf("Resume produced no content, retrying with --session-id")
+	// Retry with --session-id only when the session is actually missing (stderr
+	// marker) — a blind retry on any empty output re-runs the turn against an
+	// existing session and hides the original failure.
+	sessionMissing := <-sessErrCh
+	if hasArg(args, "--resume") && sessionMissing && lastText == "" && result == "" {
+		log.Printf("Resume session not found, retrying with --session-id")
 		retryArgs := replaceArg(args, "--resume", "--session-id")
 		return runClaude(retryArgs, prompt, workingDir, envVars)
 	}

--- a/cmd/relay-claude/process_test.go
+++ b/cmd/relay-claude/process_test.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeFakeClaude installs an executable `claude` stub into a fresh temp dir
+// and prepends that dir to PATH, so launchClaude's exec.Command("claude", ...)
+// resolves to the stub. The script sees CLI args as "$@"/"$*" and can append
+// to $ARGSLOG (passed via envVars) to record invocations.
+func writeFakeClaude(t *testing.T, script string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "claude")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func newArgsLog(t *testing.T) (logPath string, env map[string]string, count func() int) {
+	t.Helper()
+	logPath = filepath.Join(t.TempDir(), "args.log")
+	env = map[string]string{"ARGSLOG": logPath}
+	count = func() int {
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			return 0
+		}
+		return len(strings.Split(strings.TrimSpace(string(data)), "\n"))
+	}
+	return
+}
+
+func waitReadyErr(t *testing.T, ready <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-ready:
+		return err
+	case <-time.After(10 * time.Second):
+		t.Fatal("ready never fired within 10s")
+		return nil
+	}
+}
+
+func collectAllLines(t *testing.T, lines <-chan string) []string {
+	t.Helper()
+	var out []string
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case l, ok := <-lines:
+			if !ok {
+				return out
+			}
+			out = append(out, l)
+		case <-deadline:
+			t.Fatalf("timed out draining lines; got so far: %v", out)
+		}
+	}
+}
+
+const errorResultLine = `{"type":"result","subtype":"error_during_execution","is_error":true,"result":"API Error: overloaded"}`
+
+// A --resume run whose first (and only) non-init event is an error result and
+// whose stderr does NOT contain the "No conversation found" marker means the
+// session exists and claude genuinely failed (API error / rate limit / auth).
+// The old sniff discarded that entire run (result text AND usage) and blindly
+// re-ran with --session-id, which typically produced an empty 200 stream. The
+// error result must instead be forwarded downstream, with no retry.
+func TestResumeForwardsErrorResultWithoutRetry(t *testing.T) {
+	writeFakeClaude(t, `echo "$*" >> "$ARGSLOG"
+echo '{"type":"system","subtype":"init"}'
+echo '`+errorResultLine+`'
+`)
+	_, env, count := newArgsLog(t)
+
+	lines, ready, _ := startClaudeStream([]string{"--resume", "sess-x"}, "hi", "", env)
+	if err := waitReadyErr(t, ready); err != nil {
+		t.Fatalf("ready returned error, want nil: %v", err)
+	}
+	got := collectAllLines(t, lines)
+
+	joined := strings.Join(got, "\n")
+	if !strings.Contains(joined, `"result":"API Error: overloaded"`) {
+		t.Errorf("error result was not forwarded downstream; got lines: %v", got)
+	}
+	if n := count(); n != 1 {
+		t.Errorf("claude invoked %d times, want 1 (no blind --session-id retry)", n)
+	}
+}
+
+// The legitimate retry case: stderr carries the "No conversation found with
+// session ID" marker, so the session file really is missing and re-running
+// with --session-id (recreate the session) is correct.
+func TestResumeRetriesWhenSessionMissing(t *testing.T) {
+	writeFakeClaude(t, `echo "$*" >> "$ARGSLOG"
+case "$*" in
+*--session-id*)
+  echo '{"type":"system","subtype":"init"}'
+  echo '{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}}'
+  echo '{"type":"result","subtype":"success","result":"hello"}'
+  ;;
+*--resume*)
+  echo "No conversation found with session ID: sess-x" >&2
+  exit 1
+  ;;
+esac
+`)
+	_, env, count := newArgsLog(t)
+
+	lines, ready, _ := startClaudeStream([]string{"--resume", "sess-x"}, "hi", "", env)
+	if err := waitReadyErr(t, ready); err != nil {
+		t.Fatalf("ready returned error, want nil: %v", err)
+	}
+	got := collectAllLines(t, lines)
+
+	joined := strings.Join(got, "\n")
+	if !strings.Contains(joined, `"text":"hello"`) {
+		t.Errorf("retry output was not forwarded; got lines: %v", got)
+	}
+	if n := count(); n != 2 {
+		t.Errorf("claude invoked %d times, want 2 (resume + --session-id retry)", n)
+	}
+}
+
+// Zero-output exit on --resume with the session present (silent crash, or the
+// first-line watchdog killed a hung CLI): retrying with --session-id used to
+// produce a delayed empty 200 stream — the "AI 已完成处理，但未生成文本回复"
+// signature. It must surface as an error instead, with no retry.
+func TestResumeZeroOutputSessionExistsErrors(t *testing.T) {
+	writeFakeClaude(t, `echo "$*" >> "$ARGSLOG"
+exit 0
+`)
+	_, env, count := newArgsLog(t)
+
+	lines, ready, _ := startClaudeStream([]string{"--resume", "sess-x"}, "hi", "", env)
+	if err := waitReadyErr(t, ready); err == nil {
+		t.Error("ready returned nil, want error for zero-output resume run")
+	}
+	collectAllLines(t, lines)
+	if n := count(); n != 1 {
+		t.Errorf("claude invoked %d times, want 1 (no retry when session exists)", n)
+	}
+}
+
+// Session really missing, but the --session-id retry ALSO exits with zero
+// output: must be an error, never an empty 200 stream.
+func TestResumeRetryZeroOutputErrors(t *testing.T) {
+	writeFakeClaude(t, `echo "$*" >> "$ARGSLOG"
+case "$*" in
+*--session-id*)
+  exit 0
+  ;;
+*--resume*)
+  echo "No conversation found with session ID: sess-x" >&2
+  exit 1
+  ;;
+esac
+`)
+	_, env, count := newArgsLog(t)
+
+	lines, ready, _ := startClaudeStream([]string{"--resume", "sess-x"}, "hi", "", env)
+	if err := waitReadyErr(t, ready); err == nil {
+		t.Error("ready returned nil, want error for zero-output retry run")
+	}
+	collectAllLines(t, lines)
+	if n := count(); n != 2 {
+		t.Errorf("claude invoked %d times, want 2", n)
+	}
+}
+
+// Non-resume path: a zero-output exit used to fire ready<-nil and close the
+// stream, i.e. an empty 200. Must be an error.
+func TestNonResumeZeroOutputErrors(t *testing.T) {
+	writeFakeClaude(t, `exit 0`)
+
+	lines, ready, _ := startClaudeStream([]string{"--model", "m"}, "hi", "", nil)
+	if err := waitReadyErr(t, ready); err == nil {
+		t.Error("ready returned nil, want error for zero-output run")
+	}
+	collectAllLines(t, lines)
+}
+
+// A claude that hangs forever without a single stdout line (claude04-style
+// bad-binary hang) must be killed by the first-line watchdog instead of
+// stalling the request until the client's own timeout.
+func TestFirstLineWatchdogKillsSilentHang(t *testing.T) {
+	writeFakeClaude(t, `sleep 30`)
+	old := firstLineTimeout
+	firstLineTimeout = 500 * time.Millisecond
+	defer func() { firstLineTimeout = old }()
+
+	start := time.Now()
+	lines, ready, _ := startClaudeStream([]string{"--model", "m"}, "hi", "", nil)
+	if err := waitReadyErr(t, ready); err == nil {
+		t.Error("ready returned nil, want watchdog-kill error")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("watchdog took %s, want ~500ms", elapsed)
+	}
+	collectAllLines(t, lines)
+}
+
+// A resume run that prints its init event (disarming the first-line watchdog)
+// and then hangs — dead proxy, wedged API retry loop — must be killed by the
+// sniff deadline instead of stalling forever behind pre-ready keepalives.
+func TestResumeSniffWatchdogKillsPostInitHang(t *testing.T) {
+	writeFakeClaude(t, `echo '{"type":"system","subtype":"init"}'
+sleep 30`)
+	old := firstLineTimeout
+	firstLineTimeout = 500 * time.Millisecond
+	defer func() { firstLineTimeout = old }()
+
+	start := time.Now()
+	lines, ready, _ := startClaudeStream([]string{"--resume", "sess-x"}, "hi", "", nil)
+	if err := waitReadyErr(t, ready); err == nil {
+		t.Error("ready returned nil, want sniff-watchdog error")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("sniff watchdog took %s, want ~500ms", elapsed)
+	}
+	collectAllLines(t, lines)
+}
+
+// A stderr line larger than bufio.Scanner's default 64KB buffer must not end
+// the stderr scan early — the "No conversation found" marker printed after it
+// still has to gate the resume retry.
+func TestStderrOversizedLineStillDetectsMissingSession(t *testing.T) {
+	writeFakeClaude(t, `echo "$*" >> "$ARGSLOG"
+case "$*" in
+*--session-id*)
+  echo '{"type":"system","subtype":"init"}'
+  echo '{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"recovered"}}}'
+  echo '{"type":"result","subtype":"success","result":"recovered"}'
+  ;;
+*--resume*)
+  head -c 200000 /dev/zero | tr '\0' 'x' >&2
+  echo >&2
+  echo "No conversation found with session ID: sess-x" >&2
+  exit 1
+  ;;
+esac
+`)
+	_, env, count := newArgsLog(t)
+
+	lines, ready, _ := startClaudeStream([]string{"--resume", "sess-x"}, "hi", "", env)
+	if err := waitReadyErr(t, ready); err != nil {
+		t.Fatalf("ready returned error, want nil (marker after oversized line must still be seen): %v", err)
+	}
+	got := collectAllLines(t, lines)
+	if !strings.Contains(strings.Join(got, "\n"), `"text":"recovered"`) {
+		t.Errorf("retry output missing; got: %v", got)
+	}
+	if n := count(); n != 2 {
+		t.Errorf("claude invoked %d times, want 2", n)
+	}
+}
+
+// Zero-event exits whose stdout held non-JSON text (node errors printed to
+// stdout) must carry that text in the error instead of claiming "no output".
+func TestZeroEventErrorMentionsLastOutput(t *testing.T) {
+	writeFakeClaude(t, `echo "Error: Cannot find module 'foo'"
+exit 1`)
+
+	lines, ready, _ := startClaudeStream([]string{"--resume", "sess-x"}, "hi", "", nil)
+	err := waitReadyErr(t, ready)
+	if err == nil {
+		t.Fatal("ready returned nil, want error")
+	}
+	if !strings.Contains(err.Error(), "Cannot find module") {
+		t.Errorf("error %q does not mention the CLI's last output", err)
+	}
+	collectAllLines(t, lines)
+}
+
+// Non-stream counterpart: runClaude's resume retry must be gated on the
+// session-missing stderr marker too, not fired blindly on empty output.
+func TestRunClaudeNoRetryWhenSessionExists(t *testing.T) {
+	writeFakeClaude(t, `echo "$*" >> "$ARGSLOG"
+exit 0
+`)
+	_, env, count := newArgsLog(t)
+
+	_, _, _, _, _, _, err := runClaude([]string{"--resume", "sess-x"}, "hi", "", env)
+	if err != nil {
+		t.Fatalf("runClaude error: %v", err)
+	}
+	if n := count(); n != 1 {
+		t.Errorf("claude invoked %d times, want 1 (no blind retry)", n)
+	}
+}

--- a/cmd/relay-claude/stream.go
+++ b/cmd/relay-claude/stream.go
@@ -13,6 +13,11 @@ import (
 	"clawrelay-api/pkg/proc"
 )
 
+// heartbeatInterval paces the SSE comment heartbeats (`: keepalive`) that keep
+// idle-timeout proxies and clients from cutting a quiet stream. Package var so
+// tests can shorten it.
+var heartbeatInterval = 30 * time.Second
+
 // abortClaudeAndHarvestUsage 中断 V1 进程并在后台限时收割该轮 usage：
 // SIGINT → 最多 10s 内解析残余行中的 result（modelUsage 有真实值）→
 // stats.RecordTurn 记账（+日志）→ KillGroup 兜底 + 排空。
@@ -61,44 +66,99 @@ func abortClaudeAndHarvestUsage(cmd *exec.Cmd, lines <-chan string, model, sessi
 	}()
 }
 
-// handleStreamResponse streams Claude output without tool-call detection.
-// Used when no tools are defined in the request (fast path). The stream-json →
-// OpenAI SSE translation is delegated to sseTranslator (shared with the
-// channel-mode handler); this function owns only the per-request process
-// lifecycle, heartbeats and disconnect handling.
-func handleStreamResponse(w http.ResponseWriter, r *http.Request, args []string, prompt, chatID string, created int64, model string, includeUsage bool, workingDir string, envVars map[string]string, sessionID string) {
-	lines, ready, cmdPtr := startClaudeStream(args, prompt, workingDir, envVars)
-	if err := <-ready; err != nil {
-		openai.WriteError(w, http.StatusInternalServerError, "server_error", err.Error())
-		return
+// sseHandshake sends the SSE response headers and the first `: ping` BEFORE
+// claude is ready. ready waits for the CLI's first stdout line (the resume
+// sniff path even runs a whole first process), so a slow-starting or hung CLI
+// used to leave the client with zero bytes — not even response headers — until
+// its read timeout cut the connection (wuji-tools: sock_read=120s →
+// "AI 连接出现错误"). Same approach as the V2 channel handler.
+//
+// Returns ok=false after cleaning up when streaming is unsupported. Once this
+// returns ok=true the status code is out: every later failure must close the
+// stream with an in-stream error chunk, not an HTTP error.
+func sseHandshake(w http.ResponseWriter, ready <-chan error, handle *procHandle, lines <-chan string) (http.Flusher, *time.Ticker, bool) {
+	flusher, isFlusher := w.(http.Flusher)
+	if !isFlusher {
+		// 部署/中间件问题：没有 flusher 做不了 SSE。头还没发，用标准 500，
+		// 后台等进程起来后杀掉排空。
+		log.Printf("Streaming not supported")
+		openai.WriteError(w, http.StatusInternalServerError, "server_error", "streaming unsupported by this connection")
+		go func() {
+			if err := <-ready; err == nil {
+				if cmd := handle.abort(); cmd != nil {
+					proc.KillGroup(cmd)
+				}
+			}
+			proc.DrainLines(lines)
+		}()
+		return nil, nil, false
 	}
-
-	// Disconnect handling is inline in the loop below (single goroutine
-	// watching ctx), so there is no watcher/loop race on ctx.
 
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
 	w.WriteHeader(http.StatusOK)
-
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		// 非用户中断（本地 ResponseWriter 不支持 flush，属于部署/中间件问题），
-		// 不做 SIGINT 收割：直接杀掉并排空即可。
-		log.Printf("Streaming not supported")
-		if cmd := *cmdPtr; cmd != nil {
-			proc.KillGroup(cmd)
-		}
-		proc.DrainLines(lines)
-		return
-	}
-
 	fmt.Fprintf(w, ": ping\n\n")
 	flusher.Flush()
 
-	heartbeatTicker := time.NewTicker(30 * time.Second)
+	return flusher, time.NewTicker(heartbeatInterval), true
+}
+
+// waitClaudeReady blocks until startClaudeStream's ready fires, keeping the
+// (already-started) SSE stream alive with comment heartbeats and honoring
+// client disconnects. Startup failures — fork error, zero-output crash,
+// first-line watchdog kill, failed resume retry — are emitted as a visible
+// in-stream error chunk + [DONE] (the status code is long gone), so the
+// upstream client renders the reason instead of an empty reply or a timeout.
+// Returns false when the handler must stop (error emitted or client gone).
+func waitClaudeReady(w http.ResponseWriter, r *http.Request, flusher http.Flusher, heartbeatTicker *time.Ticker, ready <-chan error, handle *procHandle, lines <-chan string, chatID string, created int64, model, sessionID string) bool {
+	for {
+		select {
+		case err := <-ready:
+			if err != nil {
+				log.Printf("claude startup failed: chat=%s session=%s: %v", chatID, sessionID, err)
+				channelEmitErrClose(w, flusher, chatID, created, model, err.Error())
+				proc.DrainLines(lines)
+				return false
+			}
+			return true
+		case <-heartbeatTicker.C:
+			fmt.Fprintf(w, ": keepalive\n\n")
+			flusher.Flush()
+		case <-r.Context().Done():
+			// Client gone while claude was still starting: same treatment as a
+			// mid-stream disconnect.
+			if cmd := handle.abort(); cmd != nil {
+				abortClaudeAndHarvestUsage(cmd, lines, model, sessionID)
+			} else {
+				proc.DrainLines(lines)
+			}
+			return false
+		}
+	}
+}
+
+// handleStreamResponse streams Claude output without tool-call detection.
+// Used when no tools are defined in the request (fast path). The stream-json →
+// OpenAI SSE translation is delegated to sseTranslator (shared with the
+// channel-mode handler); this function owns only the per-request process
+// lifecycle, heartbeats and disconnect handling.
+func handleStreamResponse(w http.ResponseWriter, r *http.Request, args []string, prompt, chatID string, created int64, model string, includeUsage bool, workingDir string, envVars map[string]string, sessionID string) {
+	lines, ready, handle := startClaudeStream(args, prompt, workingDir, envVars)
+
+	flusher, heartbeatTicker, ok := sseHandshake(w, ready, handle, lines)
+	if !ok {
+		return
+	}
 	defer heartbeatTicker.Stop()
+
+	// Disconnect handling is inline in the loops below (single goroutine
+	// watching ctx), so there is no watcher/loop race on ctx.
+
+	if !waitClaudeReady(w, r, flusher, heartbeatTicker, ready, handle, lines, chatID, created, model, sessionID) {
+		return
+	}
 
 	t := newSSETranslator(chatID, created, model, sessionID, identityMeter{}, "")
 
@@ -110,7 +170,7 @@ processLines:
 		case <-r.Context().Done():
 			// disconnect (= upstream stop): SIGINT + harvest the aborted turn's
 			// usage before the backstop kill (A3).
-			if cmd := *cmdPtr; cmd != nil {
+			if cmd := handle.abort(); cmd != nil {
 				abortClaudeAndHarvestUsage(cmd, lines, model, sessionID)
 			} else {
 				proc.DrainLines(lines)
@@ -130,7 +190,7 @@ processLines:
 		}
 
 		if t.feed(w, flusher, line, includeUsage) == outcomeAskUserDone {
-			if cmd := *cmdPtr; cmd != nil && cmd.Process != nil {
+			if cmd := handle.abort(); cmd != nil && cmd.Process != nil {
 				log.Printf("[ASK_USER_QUESTION] interrupting Claude process group pid=%d (usage harvest, then kill)", cmd.Process.Pid)
 				abortClaudeAndHarvestUsage(cmd, lines, model, sessionID)
 			} else {
@@ -154,37 +214,20 @@ processLines:
 // collecting full output text to detect tool calls at the end. Used when
 // tools are defined in the request.
 func handleBufferedStreamResponse(w http.ResponseWriter, r *http.Request, args []string, prompt, chatID string, created int64, model string, includeUsage bool, workingDir string, envVars map[string]string, sessionID string) {
-	lines, ready, cmdPtr := startClaudeStream(args, prompt, workingDir, envVars)
-	if err := <-ready; err != nil {
-		openai.WriteError(w, http.StatusInternalServerError, "server_error", err.Error())
+	lines, ready, handle := startClaudeStream(args, prompt, workingDir, envVars)
+
+	flusher, heartbeatTicker, ok := sseHandshake(w, ready, handle, lines)
+	if !ok {
 		return
 	}
+	defer heartbeatTicker.Stop()
 
-	// Disconnect handling is inline in the loop below (single goroutine
+	// Disconnect handling is inline in the loops below (single goroutine
 	// watching ctx), so there is no watcher/loop race on ctx.
 
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("X-Accel-Buffering", "no")
-	w.WriteHeader(http.StatusOK)
-
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		// 非用户中断（flush 不可用），不做 SIGINT 收割：直接杀掉并排空。
-		log.Printf("Streaming not supported")
-		if cmd := *cmdPtr; cmd != nil {
-			proc.KillGroup(cmd)
-		}
-		proc.DrainLines(lines)
+	if !waitClaudeReady(w, r, flusher, heartbeatTicker, ready, handle, lines, chatID, created, model, sessionID) {
 		return
 	}
-
-	fmt.Fprintf(w, ": ping\n\n")
-	flusher.Flush()
-
-	heartbeatTicker := time.NewTicker(30 * time.Second)
-	defer heartbeatTicker.Stop()
 
 	var fullText strings.Builder
 	var filter toolCallFilter
@@ -203,7 +246,7 @@ processLines:
 		case <-r.Context().Done():
 			// disconnect (= upstream stop): SIGINT + harvest the aborted turn's
 			// usage before the backstop kill (A3).
-			if cmd := *cmdPtr; cmd != nil {
+			if cmd := handle.abort(); cmd != nil {
 				abortClaudeAndHarvestUsage(cmd, lines, model, sessionID)
 			} else {
 				proc.DrainLines(lines)
@@ -299,7 +342,7 @@ processLines:
 					fmt.Fprintf(w, "data: [DONE]\n\n")
 					flusher.Flush()
 
-					if cmd := *cmdPtr; cmd != nil && cmd.Process != nil {
+					if cmd := handle.abort(); cmd != nil && cmd.Process != nil {
 						log.Printf("[ASK_USER_QUESTION] interrupting Claude process group pid=%d (usage harvest, then kill)", cmd.Process.Pid)
 						abortClaudeAndHarvestUsage(cmd, lines, model, sessionID)
 					} else {
@@ -373,6 +416,25 @@ processLines:
 		}
 
 		if event.Type == "result" {
+			// Mirror translate.go's error transparency: an error result whose
+			// explanation only lives in Result (nothing streamed yet) must be
+			// surfaced as a content delta, or the turn ends cleanly but empty —
+			// this path is hit by resume-sniff-forwarded error results too.
+			if (event.IsError || strings.HasPrefix(event.Subtype, "error")) && !streamDeltaSent && event.Result != "" {
+				log.Printf("result reports error (buffered path): subtype=%s is_error=%v chat=%s session=%s",
+					event.Subtype, event.IsError, chatID, sessionID)
+				chunk := openai.ChatCompletionResponse{
+					ID: chatID, Object: "chat.completion.chunk", Created: created, Model: model,
+					Choices: []openai.ChatCompletionChoice{{
+						Index: 0,
+						Delta: openai.NewChatMessage("assistant", "⚠️ "+event.Result),
+					}},
+					XRelayError: true,
+				}
+				data, _ := json.Marshal(chunk)
+				fmt.Fprintf(w, "data: %s\n\n", data)
+				flusher.Flush()
+			}
 			if event.Result != "" {
 				fullText.Reset()
 				fullText.WriteString(event.Result)

--- a/cmd/relay-claude/stream_test.go
+++ b/cmd/relay-claude/stream_test.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"clawrelay-api/pkg/sessions"
+)
+
+// waitProcessGone polls until the PID recorded in pidFile is dead (or was
+// never written). Fails the test if the process is still alive after 5s.
+func waitProcessGone(t *testing.T, pidFile string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(pidFile)
+		if err != nil {
+			// not (yet / ever) written — treat as gone after a grace period
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil || syscall.Kill(pid, 0) != nil {
+			return // dead
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	data, _ := os.ReadFile(pidFile)
+	if len(data) == 0 {
+		return
+	}
+	pid, _ := strconv.Atoi(strings.TrimSpace(string(data)))
+	if pid > 0 && syscall.Kill(pid, 0) == nil {
+		syscall.Kill(-pid, syscall.SIGKILL)
+		t.Fatalf("claude process %d still alive 5s after disconnect", pid)
+	}
+}
+
+// SSE headers and the first ping must go out as soon as the request is
+// accepted — NOT after claude's first stdout line. A slow or hung CLI used to
+// leave the client with zero bytes (not even response headers), which trips
+// wuji-tools' aiohttp sock_read=120s and surfaces as "AI 连接出现错误".
+func TestStreamHeadersSentBeforeClaudeFirstOutput(t *testing.T) {
+	writeFakeClaude(t, `sleep 1
+echo '{"type":"system","subtype":"init"}'
+echo '{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi-there"}}}'
+echo '{"type":"result","subtype":"success","result":"hi-there"}'
+`)
+	sessionStore = sessions.New(t.TempDir())
+	oldHB := heartbeatInterval
+	heartbeatInterval = 100 * time.Millisecond
+	defer func() { heartbeatInterval = oldHB }()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleStreamResponse(w, r, []string{"--model", "m"}, "hi", "chat-1", 1, "m", false, "", nil, "")
+	}))
+	defer srv.Close()
+
+	start := time.Now()
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	headerLatency := time.Since(start)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("Content-Type = %q, want text/event-stream", ct)
+	}
+	// The stub sleeps 1s before its first line; headers must beat that.
+	if headerLatency > 700*time.Millisecond {
+		t.Errorf("headers took %s, want them before claude's first output (~1s)", headerLatency)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(body)
+	if !strings.Contains(s, ": ping") {
+		t.Errorf("body missing initial ': ping' comment:\n%s", s)
+	}
+	if !strings.Contains(s, ": keepalive") {
+		t.Errorf("body missing pre-ready ': keepalive' heartbeat (claude silent for 1s, ticker at 100ms):\n%s", s)
+	}
+	if !strings.Contains(s, "hi-there") {
+		t.Errorf("body missing streamed text:\n%s", s)
+	}
+	if !strings.Contains(s, "data: [DONE]") {
+		t.Errorf("body missing [DONE]:\n%s", s)
+	}
+}
+
+// Once headers are out, a startup failure (fork error, zero-output crash,
+// watchdog kill) can no longer become an HTTP 500 — it must close the stream
+// with a visible in-stream error chunk, mirroring the V2 channel handler.
+func TestStreamReadyErrorEmitsInStreamErrorChunk(t *testing.T) {
+	writeFakeClaude(t, `exit 0`)
+	sessionStore = sessions.New(t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleStreamResponse(w, r, []string{"--model", "m"}, "hi", "chat-2", 1, "m", false, "", nil, "")
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (headers already sent)", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(body)
+	if !strings.Contains(s, "⚠️") {
+		t.Errorf("body missing visible error chunk:\n%s", s)
+	}
+	if !strings.Contains(s, `"x_relay_error":true`) {
+		t.Errorf("error chunk missing x_relay_error marker:\n%s", s)
+	}
+	if !strings.Contains(s, `"finish_reason":"stop"`) {
+		t.Errorf("body missing terminal finish chunk:\n%s", s)
+	}
+	if !strings.Contains(s, "data: [DONE]") {
+		t.Errorf("body missing [DONE]:\n%s", s)
+	}
+}
+
+// Disconnecting while claude is still silent (pre-ready) must kill the
+// process — the pre-ready ctx.Done path reads the current cmd through
+// procHandle, which also makes this test race-clean under -race.
+func TestPreReadyDisconnectKillsClaude(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "pid")
+	writeFakeClaude(t, `echo $$ > "$PIDFILE"
+sleep 30`)
+	sessionStore = sessions.New(t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleStreamResponse(w, r, []string{"--model", "m"}, "hi", "chat-4", 1, "m", false, "",
+			map[string]string{"PIDFILE": pidFile}, "")
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Wait until the stub has started, then drop the connection mid-startup.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(pidFile); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	cancel()
+	resp.Body.Close()
+
+	waitProcessGone(t, pidFile)
+}
+
+// Disconnecting during the resume sniff must NOT let the --session-id retry
+// become an unkillable orphan: publish() after abort() kills the newcomer.
+func TestPreReadyDisconnectDoesNotOrphanRetry(t *testing.T) {
+	retryPid := filepath.Join(t.TempDir(), "retry-pid")
+	writeFakeClaude(t, `case "$*" in
+*--session-id*)
+  echo $$ > "$RETRYPID"
+  sleep 30
+  ;;
+*--resume*)
+  sleep 0.5
+  echo "No conversation found with session ID: sess-x" >&2
+  exit 1
+  ;;
+esac
+`)
+	sessionStore = sessions.New(t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleStreamResponse(w, r, []string{"--resume", "sess-x"}, "hi", "chat-5", 1, "m", false, "",
+			map[string]string{"RETRYPID": retryPid}, "")
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Cancel while the first (--resume) run is still sleeping, i.e. before the
+	// producer decides to launch the retry.
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+	resp.Body.Close()
+
+	// Either the retry was never launched, or it was killed right after
+	// publish() returned false.
+	waitProcessGone(t, retryPid)
+}
+
+// A forwarded error result must be visible on the buffered (tools) path too —
+// it has its own result branch that bypasses translate.go.
+func TestBufferedStreamErrorResultVisible(t *testing.T) {
+	writeFakeClaude(t, `echo '{"type":"system","subtype":"init"}'
+echo '`+errorResultLine+`'
+`)
+	sessionStore = sessions.New(t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleBufferedStreamResponse(w, r, []string{"--model", "m"}, "hi", "chat-6", 1, "m", false, "", nil, "")
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(body)
+	if !strings.Contains(s, "API Error: overloaded") {
+		t.Errorf("error result text not surfaced on buffered path:\n%s", s)
+	}
+	if !strings.Contains(s, `"x_relay_error":true`) {
+		t.Errorf("error chunk missing x_relay_error marker:\n%s", s)
+	}
+}
+
+// Same contract for the buffered (tools) variant.
+func TestBufferedStreamReadyErrorEmitsInStreamErrorChunk(t *testing.T) {
+	writeFakeClaude(t, `exit 0`)
+	sessionStore = sessions.New(t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleBufferedStreamResponse(w, r, []string{"--model", "m"}, "hi", "chat-3", 1, "m", false, "", nil, "")
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (headers already sent)", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(body)
+	if !strings.Contains(s, "⚠️") {
+		t.Errorf("body missing visible error chunk:\n%s", s)
+	}
+	if !strings.Contains(s, "data: [DONE]") {
+		t.Errorf("body missing [DONE]:\n%s", s)
+	}
+}

--- a/cmd/relay-claude/translate.go
+++ b/cmd/relay-claude/translate.go
@@ -327,6 +327,7 @@ func (t *sseTranslator) feed(w http.ResponseWriter, flusher http.Flusher, line s
 						Index: 0,
 						Delta: openai.NewChatMessage("assistant", "⚠️ "+event.Result),
 					}},
+					XRelayError: true,
 				})
 			}
 		}

--- a/docs/v1-ready-gating.md
+++ b/docs/v1-ready-gating.md
@@ -1,0 +1,84 @@
+# relay-claude V1「ready 门控」修复（2.2.0）
+
+> 针对生产两条高频用户可见故障的根治：下游企微机器人（wuji-tools）频繁展示
+> 「AI 已完成处理，但未生成文本回复」与「抱歉，AI 连接出现错误」。
+> 2026-07-07 根因调查结论：两大主因都在 V1 的 ready 门控设计上，且 2.1.0（PR29）未覆盖。
+
+## 根因
+
+V1 路径（`--mode=v1`，每请求 fork `claude`）存在两个由同一设计（`<-ready` 门控）派生的缺陷：
+
+1. **首字节前零字节窗口** → 下游 120s 读超时（「AI 连接出现错误」）
+   `handleStreamResponse` 把 HTTP 200 头、`: ping`、30s keepalive 全部扣到
+   `<-ready`（= claude 首行 stdout）之后。CLI 挂死（坏二进制劫持 PATH、
+   auto-updater 卡死、代理黑洞）或 resume 嗅探重跑期间，下游连响应头都收不到，
+   wuji-tools 的 aiohttp `sock_read=120` 在 120s 整把连接掐断。
+   生产实证：近 30 天 error 最大类全是 `Timeout on reading data from socket`，
+   latency 精确聚在 120.0~120.1s。V2 在 `channel_handler.go` 已独立修过同一问题，
+   V1 一直没有。
+
+2. **resume 嗅探丢弃错误 result + 盲重试空 200** →「未生成文本回复」
+   wuji-tools 对所有会话都传 `session_id`，V1 全走 `--resume` 嗅探。旧逻辑：
+   首个非 init/system 事件是 result（= CLI 只产出错误 result：API error/限流/
+   登录失效）就把第一次运行的全部输出**连错误文本和 usage 一起丢弃**，盲目换
+   `--session-id` 重跑；二次零输出仍 `ready <- nil`，返回一条延迟 15~120s 的
+   **空 200 事件流**（0 事件、0 usage、直接 [DONE]）。下游 0 个 TextDelta →
+   兜底文案，且以 status='success' 落库。该路径恰好绕过了 PR29 在
+   `translate.go` 加的错误透出。
+   生产实证：K8s 48h 内 38 条空回复 33 条同签名、38/38 无 Token 用量行；
+   空回复率 7-04 起激增 8 倍且 7-06 升 2.1.0 后不降。
+
+## 修复内容（2.2.0）
+
+### stream.go
+- `sseHandshake`：请求受理即发 200 头 + `: ping`（不再等 ready），V1 两个流式
+  handler 共用；无 flusher 时仍走标准 500（头未发出）并后台杀进程。
+- `waitClaudeReady`：pre-ready 期间跑 30s keepalive、响应客户端断连；启动失败
+  以流内 `⚠️` 错误块 + finish + [DONE] 收尾（复用 `channelEmitErrClose`）。
+- buffered（tools）路径补上错误 result 透出（镜像 translate.go），修复被转发的
+  错误 result 在该路径被吞的问题。
+
+### process.go
+- **首行看门狗**：`launchClaude` 内置，CLI 静默 `firstLineTimeout`（默认 90s，
+  `RELAY_FIRST_LINE_TIMEOUT_SECS` 可覆盖，必须 < 下游 sock_read=120s）无任何
+  stdout 即 KillGroup；stdout EOF 时在 `cmd.Wait()` 收割前解除武装（防 PID
+  复用误杀）。
+- **嗅探看门狗**：resume 嗅探整体限时（同 `firstLineTimeout`）——init 行会先于
+  API 调用到达并解除首行看门狗，其后挂死（代理死/CLI 卡重试）由嗅探看门狗兜底，
+  否则提前发头 + keepalive 会把故障从 120s 掩盖到上游总超时（600s+）。
+- **resume 嗅探重构**：全程 buffer 不丢弃；只有 stderr 出现
+  `No conversation found with session ID`（`sessErrCh`）才降级 `--session-id`
+  重试；会话存在且有 result → 原样转发（错误透出 + usage 记账生效）；任何零输出
+  路径 → `ready <- error`（经 `waitClaudeReady` 变成用户可见的 ⚠️ 块），不再有
+  空 200。零事件但 stdout 有非 JSON 文本时，错误信息附带最后一行输出。
+- **procHandle**：互斥保护的进程句柄替换裸 `**exec.Cmd`——修复 pre-ready 断连
+  读与生产者写的 data race，以及「断连后 retry 进程成为无人可杀的孤儿跑满整轮」
+  的 TOCTOU（`publish()` 在 abort 后返回 false，生产者自杀新进程）。
+- stderr scanner 加 8MB 行上限（与 stdout 一致）：超长 stderr 行不再吞掉
+  missing-session 标记、不再让子进程阻塞在 stderr 写上挂死嗅探。
+- `runClaude`（非流式）的 resume 盲重试同样加 `sessionMissing` 门控。
+
+### 协议扩展
+- 错误块（`channelEmitErrClose` 与错误 result 透出）携带顶层
+  `"x_relay_error": true` 字段。OpenAI 客户端忽略未知字段；wuji-tools 后续可据此
+  把此类轮次按 error 落库（当前会按普通文本展示 + status='success'，是已知的
+  下游配套项）。
+
+## 下游配套（wuji-tools，待办）
+- adapter/orchestrator 识别 `x_relay_error`，按 error 落库并本地化文案；
+- 零事件流（text=thinking=tool=0 且无 usage）按 error 处理；
+- `error_message` 记录异常类型名（bare TimeoutError 的 str() 为空无法归因）。
+
+## 行为变化注意
+- 启动类失败（fork 失败、二进制缺失、零输出崩溃、看门狗击杀）从 **HTTP 500**
+  变为 **200 + 流内 ⚠️ 错误块**：用户能看到具体原因，但下游在未适配
+  `x_relay_error` 前会把这类轮次记为 success（V2 自 2.1.0 起已是此行为）。
+- 会话存在但 CLI 只产出错误 result 时**不再自动重跑**——错误原样透出，用户自行
+  重试；只有会话真缺失才重建重试（行为与修复前的「偶尔自愈」不同，但消除了
+  重复执行带副作用 prompt 的风险）。
+
+## 测试
+`cmd/relay-claude/process_test.go` + `stream_test.go` 共 16 个用例，覆盖：
+错误 result 透传不重试、session 缺失才重试、零输出各路径报错、首行/嗅探双看门狗、
+pre-ready 断连杀进程（-race 验证）、断连不孤儿化 retry、超长 stderr 行、
+错误文案带最后输出、提前发头时序、错误块含 x_relay_error、buffered 路径错误透出。

--- a/pkg/openai/types.go
+++ b/pkg/openai/types.go
@@ -114,6 +114,13 @@ type ChatCompletionResponse struct {
 	Model   string                 `json:"model"`
 	Choices []ChatCompletionChoice `json:"choices"`
 	Usage   *UsageInfo             `json:"usage,omitempty"`
+	// XRelayError marks chunks whose content is a relay-generated error
+	// message (startup failure, worker crash) rather than model output. The
+	// stream still finishes with the standard finish_reason="stop" for OpenAI
+	// client compatibility; downstreams that know this extension (wuji-tools)
+	// can log the turn as an error instead of a success, while unknown clients
+	// simply ignore the field.
+	XRelayError bool `json:"x_relay_error,omitempty"`
 }
 
 type ChatCompletionChoice struct {


### PR DESCRIPTION
## 背景

生产企微机器人（wuji-tools，V1 下游）两条高频用户可见故障的根因调查（2026-07-07，代码+DB+K8s 日志三方证据闭环）定位到 V1 的 `<-ready` 门控设计：

| 用户看到 | 根因 | 生产证据 |
|---|---|---|
| 「AI 连接出现错误」 | 200 头/ping/keepalive 被扣到 CLI 首行 stdout 之后，CLI 挂死时下游 `sock_read=120s` 掐连接 | 近 30 天 error 最大类，latency 精确聚在 120.0~120.1s，覆盖全端口；V2 已在 `channel_handler.go` 独立修过同一问题 |
| 「未生成文本回复」 | resume 嗅探把「首个事件是 result」的第一次运行（含错误文本+usage）整体丢弃后盲重试，二次零输出仍返回**空 200 流** | K8s 48h 33/38 空回复同签名、38/38 无 usage 行；空回复率 7-04 起激增 8 倍、升 2.1.0 不降（该路径绕过 #29 的错误透出） |

## 修复

**stream.go**
- `sseHandshake`：请求受理即发 200 头 + `: ping`（照抄 V2 已验证的做法），无 flusher 仍走 500
- `waitClaudeReady`：pre-ready 心跳保活 + 断连处理；启动失败以流内 ⚠️ 错误块 + finish + [DONE] 收尾（复用 `channelEmitErrClose`）
- buffered(tools) 路径补错误 result 透出（镜像 translate.go）

**process.go**
- 首行看门狗：CLI 静默 90s（`RELAY_FIRST_LINE_TIMEOUT_SECS` 可调，须 < 下游 120s）无 stdout 即 KillGroup；EOF 先 disarm 再 Wait（防 PID 复用误杀）
- 嗅探看门狗：resume 嗅探整体限时——init 行先于 API 调用到达并解除首行看门狗，其后挂死（代理黑洞/CLI 卡重试）由此兜底，否则提前发头会把故障从 120s 掩盖到 600s+
- resume 嗅探重构：全程 buffer 不丢弃；仅 stderr 实锤 `No conversation found` 才 `--session-id` 重试；会话存在时错误 result **原样透传**（错误透出+usage 记账生效）；零输出一律 `ready<-err`，不再有空 200；错误信息附最后一行非 JSON 输出
- `procHandle`：互斥进程句柄替换裸 `**exec.Cmd`——修 pre-ready 断连的 data race（-race 实测复现过）+ 断连后 retry 进程孤儿化跑满整轮的 TOCTOU
- stderr scanner 加 8MB 行上限（超长行不再吞 missing-session 标记）
- `runClaude`（非流式）盲重试同样门控

**协议扩展**：错误块携带顶层 `"x_relay_error": true`（OpenAI 客户端忽略未知字段），wuji-tools 后续可据此按 error 落库——当前下游会把 ⚠️ 文本按普通回复展示且 status=success，为已知配套项（V2 自 2.1.0 起已是此行为）。

## 行为变化

- 启动类失败从 HTTP 500 → 200 + 流内 ⚠️ 块（用户可见具体原因）
- 会话存在但 CLI 只出错误 result 时不再自动重跑（消除重复执行带副作用 prompt 的风险），仅会话真缺失才重建重试

## 测试

- 16 个新单测（`process_test.go` / `stream_test.go`，fake claude stub）覆盖：错误 result 透传不重试、session 缺失才重试、零输出各路径报错、双看门狗、pre-ready 断连杀进程、断连不孤儿化 retry、超长 stderr、提前发头时序、x_relay_error 标记、buffered 错误透出
- `go test -race ./...` 全绿
- 经四镜头对抗审查（并发/协议/回归/resume 语义），全部 confirmed findings 已修复

🤖 Generated with [Claude Code](https://claude.com/claude-code)